### PR TITLE
Update to latest POD2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["solver", "apps/client/src-tauri", "db", "packages/pod2-node"]
 
 [workspace.dependencies]
-pod2 = { git = "https://github.com/0xPARC/pod2", branch = "playground-tweaks", features = [
+pod2 = { git = "https://github.com/0xPARC/pod2", rev = "ab3f9b51d176bb666d8ee9b4b53068dbaf496607", features = [
   "examples",
 ] }
 pod2_solver = { path = "solver" }

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -15,6 +15,7 @@ log = { workspace = true }
 env_logger = { workspace = true }
 itertools = { workspace = true }
 hex = { workspace = true }
+num = { workspace = true }
 
 [dev-dependencies]
 pod2 = { workspace = true, features = ["examples"] }

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -150,8 +150,11 @@ pub fn value_to_podlang_literal(value: Value) -> String {
 #[cfg(test)]
 mod tests {
     use hex::ToHex;
+    use num::BigUint;
     use pod2::{
-        backends::plonky2::mock::{mainpod::MockProver, signedpod::MockSigner},
+        backends::plonky2::{
+            mock::mainpod::MockProver, primitives::ec::schnorr::SecretKey, signedpod::Signer,
+        },
         examples::{
             attest_eth_friend, custom::eth_dos_batch, zu_kyc_sign_pod_builders, MOCK_VD_SET,
         },
@@ -172,16 +175,14 @@ mod tests {
             ..Default::default()
         };
 
-        let mut alice = MockSigner { pk: "Alice".into() };
-        let mut bob = MockSigner { pk: "Bob".into() };
-        let charlie = MockSigner {
-            pk: "Charlie".into(),
-        };
-        let _david = MockSigner { pk: "David".into() };
+        let mut alice = Signer(SecretKey(BigUint::from(1u32)));
+        let mut bob = Signer(SecretKey(BigUint::from(2u32)));
+        let charlie = Signer(SecretKey(BigUint::from(3u32)));
+        let _david = Signer(SecretKey(BigUint::from(4u32)));
 
         let alice_attestation = attest_eth_friend(&params, &mut alice, bob.public_key());
         let bob_attestation = attest_eth_friend(&params, &mut bob, charlie.public_key());
-        let batch = eth_dos_batch(&params, true).unwrap();
+        let batch = eth_dos_batch(&params).unwrap();
 
         let req1 = format!(
             r#"
@@ -284,20 +285,14 @@ mod tests {
         let const_1y = 1706367566;
 
         let (gov_id, pay_stub, sanction_list) = zu_kyc_sign_pod_builders(&params);
-        let mut signer = MockSigner {
-            pk: "ZooGov".into(),
-        };
-        let gov_id = gov_id.sign(&mut signer).unwrap();
+        let signer = Signer(SecretKey(BigUint::from(1u32)));
+        let gov_id = gov_id.sign(&signer).unwrap();
 
-        let mut signer = MockSigner {
-            pk: "ZooDeel".into(),
-        };
-        let pay_stub = pay_stub.sign(&mut signer).unwrap();
+        let signer = Signer(SecretKey(BigUint::from(2u32)));
+        let pay_stub = pay_stub.sign(&signer).unwrap();
 
-        let mut signer = MockSigner {
-            pk: "ZooOFAC".into(),
-        };
-        let sanction_list = sanction_list.sign(&mut signer).unwrap();
+        let signer = Signer(SecretKey(BigUint::from(3u32)));
+        let sanction_list = sanction_list.sign(&signer).unwrap();
 
         let zukyc_request = format!(
             r#"


### PR DESCRIPTION
This updates to a new version of the `playground-tweaks` branch which merges the latest `main`.

There are two additional commits, beyond what is present in POD2 `main`:

- A tweak to make Serialized POD IDs accessible, which I've added as a PR to POD2: https://github.com/0xPARC/pod2/pull/350
- Ad-hoc in-memory caching of `get_common_data` for MainPod, which will be superseded by Edu's caching solution later