### PR TITLE
make cache warming optional

### DIFF
--- a/apps/client/src-tauri/src/config.rs
+++ b/apps/client/src-tauri/src/config.rs
@@ -19,6 +19,8 @@ pub struct FeatureConfig {
     pub integration: bool,
     /// FrogCrypto experimental features
     pub frogcrypto: bool,
+    /// Pre-loading of pod2 artifacts
+    pub cache_warming: bool,
 }
 
 impl Default for FeatureConfig {
@@ -29,6 +31,7 @@ impl Default for FeatureConfig {
             authoring: true,
             integration: true,
             frogcrypto: true,
+            cache_warming: true,
         }
     }
 }
@@ -251,6 +254,11 @@ impl AppConfig {
                 self.features.frogcrypto = value
                     .parse()
                     .map_err(|e| format!("Invalid frogcrypto value '{value}': {e}"))?;
+            }
+            ["features", "cache_warming"] => {
+                self.features.cache_warming = value
+                    .parse()
+                    .map_err(|e| format!("Invalid cache_warming value '{value}': {e}"))?;
             }
             ["database", "path"] => {
                 self.database.path = value.to_string();

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -566,9 +566,11 @@ pub fn run() {
                 app.manage(Mutex::new(app_state));
 
                 // Spawn cache warming task in background to avoid blocking startup
-                tokio::task::spawn_blocking(|| {
-                    cache::warm_mainpod_cache();
-                });
+                if config.features.cache_warming {
+                    tokio::task::spawn_blocking(|| {
+                        cache::warm_mainpod_cache();
+                    });
+                }
             });
             Ok(())
         })


### PR DESCRIPTION
This PR adds a config option to disable cache warming.  This is convenient for testing features that do not use MainPods.