### PR TITLE
Replace author/tag inputs with dedicated "chip input" component

### DIFF
--- a/apps/client/src/components/documents/forms/PublishDocumentForm.tsx
+++ b/apps/client/src/components/documents/forms/PublishDocumentForm.tsx
@@ -1,9 +1,10 @@
-import { MessageSquareIcon, PlusIcon, Trash2Icon, XIcon } from "lucide-react";
+import { MessageSquareIcon, Trash2Icon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { fetchDocument, type DocumentMetadata } from "../../../lib/documentApi";
 import { useDraftAutoSave, type DraftContent } from "../../../lib/drafts";
 import { useDocuments } from "../../../lib/store";
 import { Button } from "../../ui/button";
+import { InlineChipInput } from "../../ui/inline-chip-input";
 import { PublishButton } from "../PublishButton";
 import { MarkdownEditor } from "../editors/MarkdownEditor";
 
@@ -43,8 +44,6 @@ export function PublishDocumentForm({
   const [authors, setAuthors] = useState<string[]>(
     initialContent?.authors ?? []
   );
-  const [tagInput, setTagInput] = useState("");
-  const [authorInput, setAuthorInput] = useState("");
   const [replyToDocument, setReplyToDocument] =
     useState<DocumentMetadata | null>(null);
   const [replyToLoading, setReplyToLoading] = useState(false);
@@ -60,39 +59,14 @@ export function PublishDocumentForm({
   }, [initialContent]);
 
   // Helper functions that mark content as changed
-  const addTag = () => {
-    const trimmedTag = tagInput.trim();
-    if (trimmedTag && !tags.includes(trimmedTag)) {
-      setTags([...tags, trimmedTag]);
-      setTagInput("");
-      markContentChanged();
-    }
-  };
-
-  const removeTag = (tagToRemove: string) => {
-    setTags(tags.filter((tag) => tag !== tagToRemove));
+  const handleTagsChange = (newTags: string[]) => {
+    setTags(newTags);
     markContentChanged();
   };
 
-  const addAuthor = () => {
-    const trimmedAuthor = authorInput.trim();
-    if (trimmedAuthor && !authors.includes(trimmedAuthor)) {
-      setAuthors([...authors, trimmedAuthor]);
-      setAuthorInput("");
-      markContentChanged();
-    }
-  };
-
-  const removeAuthor = (authorToRemove: string) => {
-    setAuthors(authors.filter((author) => author !== authorToRemove));
+  const handleAuthorsChange = (newAuthors: string[]) => {
+    setAuthors(newAuthors);
     markContentChanged();
-  };
-
-  const handleKeyPress = (e: React.KeyboardEvent, action: () => void) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      action();
-    }
   };
 
   // Get current form content as DraftContent
@@ -225,72 +199,20 @@ export function PublishDocumentForm({
         </div>
 
         {/* Tags Section */}
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground">Tags:</span>
-          <div className="flex items-center gap-1">
-            {tags.map((tag) => (
-              <div
-                key={tag}
-                className="inline-flex items-center gap-1 px-2 py-1 bg-muted rounded-md text-sm"
-              >
-                <span>{tag}</span>
-                <button
-                  onClick={() => removeTag(tag)}
-                  className="hover:text-destructive"
-                >
-                  <XIcon className="h-3 w-3" />
-                </button>
-              </div>
-            ))}
-            <input
-              type="text"
-              placeholder={tags.length === 0 ? "Add tags..." : ""}
-              value={tagInput}
-              onChange={(e) => setTagInput(e.target.value)}
-              onKeyPress={(e) => handleKeyPress(e, addTag)}
-              autoComplete="off"
-              autoCorrect="off"
-              className="bg-transparent border-none outline-none text-sm placeholder:text-muted-foreground w-20 min-w-[5rem]"
-            />
-            <Button type="button" variant="ghost" size="sm" onClick={addTag}>
-              <PlusIcon className="h-3 w-3" />
-            </Button>
-          </div>
-        </div>
+        <InlineChipInput
+          label="Tags"
+          placeholder="Add tags..."
+          values={tags}
+          onValuesChange={handleTagsChange}
+        />
 
         {/* Authors Section */}
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground">Authors:</span>
-          <div className="flex items-center gap-1">
-            {authors.map((author) => (
-              <div
-                key={author}
-                className="inline-flex items-center gap-1 px-2 py-1 bg-muted/50 border rounded-md text-sm"
-              >
-                <span>{author}</span>
-                <button
-                  onClick={() => removeAuthor(author)}
-                  className="hover:text-destructive"
-                >
-                  <XIcon className="h-3 w-3" />
-                </button>
-              </div>
-            ))}
-            <input
-              type="text"
-              placeholder={authors.length === 0 ? "Add authors..." : ""}
-              value={authorInput}
-              onChange={(e) => setAuthorInput(e.target.value)}
-              onKeyPress={(e) => handleKeyPress(e, addAuthor)}
-              autoComplete="off"
-              autoCorrect="off"
-              className="bg-transparent border-none outline-none text-sm placeholder:text-muted-foreground w-24 min-w-[6rem]"
-            />
-            <Button type="button" variant="ghost" size="sm" onClick={addAuthor}>
-              <PlusIcon className="h-3 w-3" />
-            </Button>
-          </div>
-        </div>
+        <InlineChipInput
+          label="Authors"
+          placeholder="Add authors..."
+          values={authors}
+          onValuesChange={handleAuthorsChange}
+        />
 
         {/* Action Buttons */}
         <div className="flex items-center gap-3 shrink-0">

--- a/apps/client/src/components/documents/forms/PublishFileForm.tsx
+++ b/apps/client/src/components/documents/forms/PublishFileForm.tsx
@@ -1,8 +1,7 @@
-import { PlusIcon, XIcon } from "lucide-react";
 import { useState } from "react";
-import { Badge } from "../../ui/badge";
 import { Button } from "../../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../ui/card";
+import { ChipInput } from "../../ui/chip-input";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
 import { PublishButton } from "../PublishButton";
@@ -21,40 +20,7 @@ export function PublishFileForm({
   const [titleTouched, setTitleTouched] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [tags, setTags] = useState<string[]>([]);
-  const [tagInput, setTagInput] = useState("");
   const [authors, setAuthors] = useState<string[]>([]);
-  const [authorInput, setAuthorInput] = useState("");
-
-  const addTag = () => {
-    const trimmedTag = tagInput.trim();
-    if (trimmedTag && !tags.includes(trimmedTag)) {
-      setTags([...tags, trimmedTag]);
-      setTagInput("");
-    }
-  };
-
-  const removeTag = (tagToRemove: string) => {
-    setTags(tags.filter((tag) => tag !== tagToRemove));
-  };
-
-  const addAuthor = () => {
-    const trimmedAuthor = authorInput.trim();
-    if (trimmedAuthor && !authors.includes(trimmedAuthor)) {
-      setAuthors([...authors, trimmedAuthor]);
-      setAuthorInput("");
-    }
-  };
-
-  const removeAuthor = (authorToRemove: string) => {
-    setAuthors(authors.filter((author) => author !== authorToRemove));
-  };
-
-  const handleKeyPress = (e: React.KeyboardEvent, action: () => void) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      action();
-    }
-  };
 
   const getPublishData = () => {
     return {
@@ -122,86 +88,23 @@ export function PublishFileForm({
         </div>
 
         {/* Tags */}
-        <div className="space-y-2">
-          <Label>Tags (optional)</Label>
-          <div className="flex gap-2">
-            <Input
-              placeholder="Add a tag..."
-              value={tagInput}
-              onChange={(e) => setTagInput(e.target.value)}
-              onKeyPress={(e) => handleKeyPress(e, addTag)}
-              className="flex-1"
-            />
-            <Button type="button" variant="outline" size="sm" onClick={addTag}>
-              <PlusIcon className="h-4 w-4" />
-            </Button>
-          </div>
-          {tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 mt-2">
-              {tags.map((tag) => (
-                <Badge
-                  key={tag}
-                  variant="secondary"
-                  className="flex items-center gap-1"
-                >
-                  {tag}
-                  <button
-                    onClick={() => removeTag(tag)}
-                    className="ml-1 hover:text-destructive"
-                  >
-                    <XIcon className="h-3 w-3" />
-                  </button>
-                </Badge>
-              ))}
-            </div>
-          )}
-        </div>
+        <ChipInput
+          label="Tags (optional)"
+          placeholder="Add a tag..."
+          values={tags}
+          onValuesChange={setTags}
+          variant="secondary"
+        />
 
         {/* Authors */}
-        <div className="space-y-2">
-          <Label>Authors (optional)</Label>
-          <div className="flex gap-2">
-            <Input
-              placeholder="Add an author..."
-              value={authorInput}
-              onChange={(e) => setAuthorInput(e.target.value)}
-              onKeyPress={(e) => handleKeyPress(e, addAuthor)}
-              autoComplete="off"
-              className="flex-1"
-            />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={addAuthor}
-            >
-              <PlusIcon className="h-4 w-4" />
-            </Button>
-          </div>
-          {authors.length > 0 && (
-            <div className="flex flex-wrap gap-2 mt-2">
-              {authors.map((author) => (
-                <Badge
-                  key={author}
-                  variant="outline"
-                  className="flex items-center gap-1"
-                >
-                  {author}
-                  <button
-                    onClick={() => removeAuthor(author)}
-                    className="ml-1 hover:text-destructive"
-                  >
-                    <XIcon className="h-3 w-3" />
-                  </button>
-                </Badge>
-              ))}
-            </div>
-          )}
-          <p className="text-sm text-muted-foreground">
-            If no authors are specified, you will be listed as the default
-            author.
-          </p>
-        </div>
+        <ChipInput
+          label="Authors (optional)"
+          placeholder="Add an author..."
+          values={authors}
+          onValuesChange={setAuthors}
+          variant="outline"
+          helpText="If no authors are specified, you will be listed as the default author."
+        />
 
         {/* Action Buttons */}
         <div className="flex justify-between pt-4 border-t">

--- a/apps/client/src/components/documents/forms/PublishLinkForm.tsx
+++ b/apps/client/src/components/documents/forms/PublishLinkForm.tsx
@@ -1,8 +1,7 @@
-import { PlusIcon, XIcon } from "lucide-react";
 import { useState } from "react";
-import { Badge } from "../../ui/badge";
 import { Button } from "../../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../ui/card";
+import { ChipInput } from "../../ui/chip-input";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
 import { PublishButton } from "../PublishButton";
@@ -21,40 +20,7 @@ export function PublishLinkForm({
   const [titleTouched, setTitleTouched] = useState(false);
   const [url, setUrl] = useState("");
   const [tags, setTags] = useState<string[]>([]);
-  const [tagInput, setTagInput] = useState("");
   const [authors, setAuthors] = useState<string[]>([]);
-  const [authorInput, setAuthorInput] = useState("");
-
-  const addTag = () => {
-    const trimmedTag = tagInput.trim();
-    if (trimmedTag && !tags.includes(trimmedTag)) {
-      setTags([...tags, trimmedTag]);
-      setTagInput("");
-    }
-  };
-
-  const removeTag = (tagToRemove: string) => {
-    setTags(tags.filter((tag) => tag !== tagToRemove));
-  };
-
-  const addAuthor = () => {
-    const trimmedAuthor = authorInput.trim();
-    if (trimmedAuthor && !authors.includes(trimmedAuthor)) {
-      setAuthors([...authors, trimmedAuthor]);
-      setAuthorInput("");
-    }
-  };
-
-  const removeAuthor = (authorToRemove: string) => {
-    setAuthors(authors.filter((author) => author !== authorToRemove));
-  };
-
-  const handleKeyPress = (e: React.KeyboardEvent, action: () => void) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      action();
-    }
-  };
 
   const getPublishData = () => {
     return {
@@ -122,86 +88,23 @@ export function PublishLinkForm({
         </div>
 
         {/* Tags */}
-        <div className="space-y-2">
-          <Label>Tags (optional)</Label>
-          <div className="flex gap-2">
-            <Input
-              placeholder="Add a tag..."
-              value={tagInput}
-              onChange={(e) => setTagInput(e.target.value)}
-              onKeyPress={(e) => handleKeyPress(e, addTag)}
-              className="flex-1"
-            />
-            <Button type="button" variant="outline" size="sm" onClick={addTag}>
-              <PlusIcon className="h-4 w-4" />
-            </Button>
-          </div>
-          {tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 mt-2">
-              {tags.map((tag) => (
-                <Badge
-                  key={tag}
-                  variant="secondary"
-                  className="flex items-center gap-1"
-                >
-                  {tag}
-                  <button
-                    onClick={() => removeTag(tag)}
-                    className="ml-1 hover:text-destructive"
-                  >
-                    <XIcon className="h-3 w-3" />
-                  </button>
-                </Badge>
-              ))}
-            </div>
-          )}
-        </div>
+        <ChipInput
+          label="Tags (optional)"
+          placeholder="Add a tag..."
+          values={tags}
+          onValuesChange={setTags}
+          variant="secondary"
+        />
 
         {/* Authors */}
-        <div className="space-y-2">
-          <Label>Authors (optional)</Label>
-          <div className="flex gap-2">
-            <Input
-              placeholder="Add an author..."
-              value={authorInput}
-              onChange={(e) => setAuthorInput(e.target.value)}
-              onKeyPress={(e) => handleKeyPress(e, addAuthor)}
-              autoComplete="off"
-              className="flex-1"
-            />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={addAuthor}
-            >
-              <PlusIcon className="h-4 w-4" />
-            </Button>
-          </div>
-          {authors.length > 0 && (
-            <div className="flex flex-wrap gap-2 mt-2">
-              {authors.map((author) => (
-                <Badge
-                  key={author}
-                  variant="outline"
-                  className="flex items-center gap-1"
-                >
-                  {author}
-                  <button
-                    onClick={() => removeAuthor(author)}
-                    className="ml-1 hover:text-destructive"
-                  >
-                    <XIcon className="h-3 w-3" />
-                  </button>
-                </Badge>
-              ))}
-            </div>
-          )}
-          <p className="text-sm text-muted-foreground">
-            If no authors are specified, you will be listed as the default
-            author.
-          </p>
-        </div>
+        <ChipInput
+          label="Authors (optional)"
+          placeholder="Add an author..."
+          values={authors}
+          onValuesChange={setAuthors}
+          variant="outline"
+          helpText="If no authors are specified, you will be listed as the default author."
+        />
 
         {/* Action Buttons */}
         <div className="flex justify-between pt-4 border-t">

--- a/apps/client/src/components/ui/chip-input.tsx
+++ b/apps/client/src/components/ui/chip-input.tsx
@@ -1,0 +1,101 @@
+import { PlusIcon, XIcon } from "lucide-react";
+import { useState, KeyboardEvent } from "react";
+import { Badge } from "./badge";
+import { Button } from "./button";
+import { Input } from "./input";
+import { Label } from "./label";
+
+interface ChipInputProps {
+  label: string;
+  placeholder: string;
+  values: string[];
+  onValuesChange: (values: string[]) => void;
+  variant?: "secondary" | "outline" | "default";
+  helpText?: string;
+  className?: string;
+}
+
+export function ChipInput({
+  label,
+  placeholder,
+  values,
+  onValuesChange,
+  variant = "secondary",
+  helpText,
+  className
+}: ChipInputProps) {
+  const [inputValue, setInputValue] = useState("");
+
+  const addValue = () => {
+    const trimmedValue = inputValue.trim();
+    if (trimmedValue && !values.includes(trimmedValue)) {
+      onValuesChange([...values, trimmedValue]);
+      setInputValue("");
+    }
+  };
+
+  const removeValue = (valueToRemove: string) => {
+    onValuesChange(values.filter((value) => value !== valueToRemove));
+  };
+
+  const handleKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addValue();
+    }
+  };
+
+  const handleBlur = () => {
+    // Add on blur if the input has content
+    if (inputValue.trim()) {
+      addValue();
+    }
+  };
+
+  return (
+    <div className={`space-y-2 ${className || ""}`}>
+      <Label>{label}</Label>
+      <div className="flex gap-2">
+        <Input
+          placeholder={placeholder}
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyPress={handleKeyPress}
+          onBlur={handleBlur}
+          autoComplete="off"
+          className="flex-1"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={addValue}
+          data-chip-add-button
+        >
+          <PlusIcon className="h-4 w-4" />
+        </Button>
+      </div>
+      {values.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-2">
+          {values.map((value) => (
+            <Badge
+              key={value}
+              variant={variant}
+              className="flex items-center gap-1"
+            >
+              {value}
+              <button
+                onClick={() => removeValue(value)}
+                className="ml-1 hover:text-destructive"
+                type="button"
+              >
+                <XIcon className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+      {helpText && <p className="text-sm text-muted-foreground">{helpText}</p>}
+    </div>
+  );
+}

--- a/apps/client/src/components/ui/inline-chip-input.tsx
+++ b/apps/client/src/components/ui/inline-chip-input.tsx
@@ -1,0 +1,90 @@
+import { PlusIcon, XIcon } from "lucide-react";
+import { useState, KeyboardEvent } from "react";
+import { Button } from "./button";
+
+interface InlineChipInputProps {
+  label: string;
+  placeholder: string;
+  values: string[];
+  onValuesChange: (values: string[]) => void;
+  className?: string;
+}
+
+export function InlineChipInput({
+  label,
+  placeholder,
+  values,
+  onValuesChange,
+  className
+}: InlineChipInputProps) {
+  const [inputValue, setInputValue] = useState("");
+
+  const addValue = () => {
+    const trimmedValue = inputValue.trim();
+    if (trimmedValue && !values.includes(trimmedValue)) {
+      onValuesChange([...values, trimmedValue]);
+      setInputValue("");
+    }
+  };
+
+  const removeValue = (valueToRemove: string) => {
+    onValuesChange(values.filter((value) => value !== valueToRemove));
+  };
+
+  const handleKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addValue();
+    }
+  };
+
+  const handleBlur = () => {
+    // Add on blur if the input has content
+    if (inputValue.trim()) {
+      addValue();
+    }
+  };
+
+  return (
+    <div className={`flex items-center gap-2 ${className || ""}`}>
+      <span className="text-sm text-muted-foreground">{label}:</span>
+      <div className="flex items-center gap-1">
+        {values.map((value) => (
+          <div
+            key={value}
+            className="inline-flex items-center gap-1 px-2 py-1 bg-muted rounded-md text-sm"
+          >
+            <span>{value}</span>
+            <button
+              onClick={() => removeValue(value)}
+              className="hover:text-destructive"
+              type="button"
+            >
+              <XIcon className="h-3 w-3" />
+            </button>
+          </div>
+        ))}
+        <input
+          type="text"
+          placeholder={values.length === 0 ? placeholder : ""}
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyPress={handleKeyPress}
+          onBlur={handleBlur}
+          autoComplete="off"
+          autoCorrect="off"
+          className="bg-transparent border-none outline-none text-sm placeholder:text-muted-foreground w-20 min-w-[5rem]"
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={addValue}
+          data-chip-add-button
+        >
+          <PlusIcon className="h-3 w-3" />
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Replaces the Author and Tags inputs with a "chip input" component.

This also behaves slightly differently: inputs are added when you tab/click away from the component, without requiring pressing enter or clicking the "+" button. This seems to align more closely to user expectations.