### PR TITLE
Fix the publickeyof handling in the solver

### DIFF
--- a/core/new_solver/src/handlers/publickeyof.rs
+++ b/core/new_solver/src/handlers/publickeyof.rs
@@ -54,8 +54,8 @@ impl OpHandler for PublicKeyOfHandler {
             return PropagatorResult::Contradiction;
         }
 
-        let a_secret_key = &args[0];
-        let a_public_key = &args[1];
+        let a_public_key = &args[0];
+        let a_secret_key = &args[1];
 
         // Extract secret key if available
         let sk_opt: Option<SecretKey> = match a_secret_key {
@@ -188,16 +188,16 @@ mod tests {
         let mut store = ConstraintStore::default();
         let sk = SecretKey::new_rand();
         let pk_val = Value::from(sk.public_key());
-        store.bindings.insert(0, Value::from(sk));
+        store.bindings.insert(1, Value::from(sk));
 
         let handler = PublicKeyOfHandler;
-        let args = args_from("REQUEST(PublicKeyOf(?SK, ?PK))");
+        let args = args_from("REQUEST(PublicKeyOf(?PK, ?SK))");
         let res = handler.propagate(&args, &mut store, &edb);
 
         match res {
             PropagatorResult::Entailed { bindings, op_tag } => {
                 assert_eq!(bindings.len(), 1);
-                assert_eq!(bindings[0].0, 1); // ?PK index
+                assert_eq!(bindings[0].0, 0); // ?PK index
                 assert_eq!(bindings[0].1, pk_val);
                 assert!(matches!(op_tag, OpTag::FromLiterals));
             }
@@ -214,16 +214,16 @@ mod tests {
 
         let edb = ImmutableEdbBuilder::new().add_keypair(pk, sk).build();
         let mut store = ConstraintStore::default();
-        store.bindings.insert(1, pk_val.clone());
+        store.bindings.insert(0, pk_val.clone());
 
         let handler = PublicKeyOfHandler;
-        let args = args_from("REQUEST(PublicKeyOf(?SK, ?PK))");
+        let args = args_from("REQUEST(PublicKeyOf(?PK, ?SK))");
         let res = handler.propagate(&args, &mut store, &edb);
 
         match res {
             PropagatorResult::Entailed { bindings, op_tag } => {
                 assert_eq!(bindings.len(), 1);
-                assert_eq!(bindings[0].0, 0); // ?SK index
+                assert_eq!(bindings[0].0, 1); // ?SK index
                 assert_eq!(bindings[0].1, sk_val);
                 assert!(matches!(op_tag, OpTag::FromLiterals));
             }

--- a/core/new_solver/src/handlers/publickeyof.rs
+++ b/core/new_solver/src/handlers/publickeyof.rs
@@ -146,8 +146,40 @@ impl OpHandler for PublicKeyOfHandler {
                 }
             }
 
-            // Case 3: Neither secret key nor public key is known. Suspend.
+            // Case 3: Neither secret key nor public key is known.
             (None, None) => {
+                // Enumeration: when both are unbound wildcards, enumerate all keypairs from the EDB
+                if let (StatementTmplArg::Wildcard(wsk), StatementTmplArg::Wildcard(wpk)) =
+                    (a_secret_key, a_public_key)
+                {
+                    if !store.bindings.contains_key(&wsk.index)
+                        && !store.bindings.contains_key(&wpk.index)
+                    {
+                        let mut alts = Vec::new();
+                        for (pk_val, sk_val) in edb.enumerate_keypairs() {
+                            // Extract the actual keypair values for the OpTag
+                            if let (Ok(sk), Ok(pk)) = (
+                                pod2::middleware::SecretKey::try_from(sk_val.typed()),
+                                pod2::middleware::PublicKey::try_from(pk_val.typed()),
+                            ) {
+                                alts.push(crate::prop::Choice {
+                                    bindings: vec![(wsk.index, sk_val), (wpk.index, pk_val)],
+                                    op_tag: OpTag::GeneratedPublicKeyOf {
+                                        secret_key: sk,
+                                        public_key: pk,
+                                    },
+                                });
+                            }
+                        }
+                        tracing::trace!(candidates = alts.len(), "PublicKeyOf enum all keypairs");
+                        return if alts.is_empty() {
+                            PropagatorResult::Contradiction
+                        } else {
+                            PropagatorResult::Choices { alternatives: alts }
+                        };
+                    }
+                }
+
                 let waits = crate::prop::wildcards_in_args(args)
                     .into_iter()
                     .filter(|i| !store.bindings.contains_key(i))

--- a/core/new_solver/src/op.rs
+++ b/core/new_solver/src/op.rs
@@ -33,6 +33,7 @@ impl Default for OpRegistry {
         crate::handlers::register_maxof_handlers(&mut reg);
         crate::handlers::register_hashof_handlers(&mut reg);
         crate::handlers::register_not_equal_handlers(&mut reg);
+        crate::handlers::register_publickeyof_handlers(&mut reg);
         reg
     }
 }

--- a/core/new_solver/src/proof_dag.rs
+++ b/core/new_solver/src/proof_dag.rs
@@ -50,7 +50,8 @@ impl ProofDag {
                 }
                 OpTag::CopyStatement { .. }
                 | OpTag::FromLiterals
-                | OpTag::GeneratedContains { .. } => {
+                | OpTag::GeneratedContains { .. }
+                | OpTag::GeneratedPublicKeyOf { .. } => {
                     // Leaf; no extra edges
                 }
             }
@@ -225,7 +226,8 @@ impl ProofDagWithOps {
                 }
                 OpTag::CopyStatement { .. }
                 | OpTag::FromLiterals
-                | OpTag::GeneratedContains { .. } => {
+                | OpTag::GeneratedContains { .. }
+                | OpTag::GeneratedPublicKeyOf { .. } => {
                     // Leaves: no premise statements to attach
                 }
             }
@@ -376,6 +378,10 @@ fn short_op_key(tag: &OpTag) -> String {
             key.name(),
             value.raw().encode_hex::<String>()
         ),
+        OpTag::GeneratedPublicKeyOf {
+            secret_key,
+            public_key,
+        } => format!("gen_publickeyof:{}:{}", secret_key, &public_key),
         OpTag::Derived { .. } => "derived".to_string(),
         OpTag::CustomDeduction { rule_id, .. } => format!("custom:{rule_id:?}"),
     }
@@ -395,6 +401,14 @@ fn short_op_label(tag: &OpTag) -> String {
             root.encode_hex::<String>(),
             key.name(),
             value
+        ),
+        OpTag::GeneratedPublicKeyOf {
+            secret_key,
+            public_key,
+        } => format!(
+            "GeneratedPublicKeyOf\nsk=0x{}\\npk=0x{}",
+            hex::ToHex::encode_hex::<String>(&secret_key.as_bytes()),
+            public_key,
         ),
         OpTag::Derived { .. } => "Derived".to_string(),
         OpTag::CustomDeduction { rule_id, .. } => {

--- a/core/new_solver/src/replay.rs
+++ b/core/new_solver/src/replay.rs
@@ -646,6 +646,10 @@ fn order_custom_premises(
                             && arg_matches(&args[1], &a1)
                             && arg_matches(&args[2], &a2)
                     }
+                    (Predicate::Native(NP::PublicKeyOf), Stmt::PublicKeyOf(a0, a1)) => {
+                        let args = tmpl.args();
+                        arg_matches(&args[0], &a0) && arg_matches(&args[1], &a1)
+                    }
                     _ => false,
                 });
         if let Some(pos) = matched_pos {

--- a/core/new_solver/src/types.rs
+++ b/core/new_solver/src/types.rs
@@ -42,6 +42,12 @@ pub enum OpTag {
         key: Key,
         value: Value,
     },
+    /// A PublicKeyOf premise that is justified because the solver has the keypair
+    /// and can generate the public key from the secret key.
+    GeneratedPublicKeyOf {
+        secret_key: pod2::middleware::SecretKey,
+        public_key: pod2::middleware::PublicKey,
+    },
 }
 
 /// Provenance reference to a POD for CopyStatement.

--- a/core/new_solver/src/util.rs
+++ b/core/new_solver/src/util.rs
@@ -270,7 +270,17 @@ pub fn instantiate_goal(
             let a2 = arg_to_vr(&tmpl.args[2], bindings)?;
             Some(Statement::HashOf(a0, a1, a2))
         }
-        _ => None,
+        Predicate::Native(NativePredicate::PublicKeyOf) => {
+            if tmpl.args.len() != 2 {
+                return None;
+            }
+            let a0 = arg_to_vr(&tmpl.args[0], bindings)?;
+            let a1 = arg_to_vr(&tmpl.args[1], bindings)?;
+            Some(Statement::PublicKeyOf(a0, a1))
+        }
+        _ => {
+            panic!("Unrecognized predicate head: {}", tmpl.pred);
+        }
     }
 }
 

--- a/core/new_solver/src/util.rs
+++ b/core/new_solver/src/util.rs
@@ -158,7 +158,9 @@ pub fn proof_cost(store: &ConstraintStore) -> (usize, usize) {
                     q.push_back(p);
                 }
             }
-            OpTag::GeneratedContains { .. } | OpTag::FromLiterals => {}
+            OpTag::GeneratedContains { .. }
+            | OpTag::GeneratedPublicKeyOf { .. }
+            | OpTag::FromLiterals => {}
         }
     }
     (seen_stmts.len(), seen_inputs.len())


### PR DESCRIPTION
This fixes the publickeyof handler in the solver. In particular, there were some cases in src/utils.rs which didn't handle the predicate properly, and the handler had the public key and secret key args in the wrong order.