### PR TITLE
Update to pod2 repo with prefixless wildcards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 , "podnet/identity-github"]
 
 [workspace.dependencies]
-pod2 = { git = "https://github.com/0xPARC/pod2", rev = "b02d0ec46247f3f64bd4d2e30db9da7f40903409", default-features = false,  features = [  "backend_plonky2", "zk", "examples", "disk_cache" ] }
+pod2 = { git = "https://github.com/0xPARC/pod2", rev = "7e04eb51ff34f7947f396ef30b8e53edc1dc3f2c", default-features = false,  features = [  "backend_plonky2", "zk", "examples", "disk_cache" ] }
 pod2_solver = { path = "core/new_solver" }
 podnet-models = { path = "core/models" }
 pod-utils = { path = "core/utils" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 , "podnet/identity-github"]
 
 [workspace.dependencies]
-pod2 = { git = "https://github.com/0xPARC/pod2", rev = "7e04eb51ff34f7947f396ef30b8e53edc1dc3f2c", default-features = false,  features = [  "backend_plonky2", "zk", "examples", "disk_cache" ] }
+pod2 = { git = "https://github.com/0xPARC/pod2", rev = "354a656c03f76ca03649629630233c2314f4bcef", default-features = false,  features = [  "backend_plonky2", "zk", "examples", "disk_cache" ] }
 pod2_solver = { path = "core/new_solver" }
 podnet-models = { path = "core/models" }
 pod-utils = { path = "core/utils" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 , "podnet/identity-github"]
 
 [workspace.dependencies]
-pod2 = { git = "https://github.com/0xPARC/pod2", rev = "354a656c03f76ca03649629630233c2314f4bcef", default-features = false,  features = [  "backend_plonky2", "zk", "examples", "disk_cache" ] }
+pod2 = { git = "https://github.com/0xPARC/pod2", rev = "5de08da32cdbd3e8e4476585a6a97529c578ac68", default-features = false,  features = [  "backend_plonky2", "zk", "examples", "disk_cache" ] }
 pod2_solver = { path = "core/new_solver" }
 podnet-models = { path = "core/models" }
 pod-utils = { path = "core/utils" }

--- a/apps/client/src/lib/features/authoring/monaco.ts
+++ b/apps/client/src/lib/features/authoring/monaco.ts
@@ -106,7 +106,7 @@ export const PodlangMonarchLanguage: languages.IMonarchLanguage = {
         }
       ],
 
-      // Anchored Keys: ?var["key"]
+      // Anchored Keys: var["key"]
       [/\\?[a-zA-Z_][a-zA-Z0-9_]*\\["[^"]*"\\]/, "variable.anchored.Podlang"],
 
       // Variables: start with '?', use explicit char class
@@ -282,8 +282,8 @@ export function getDefaultEditorContent(): string {
 //
 // Example:
 // REQUEST(
-//     Equal(?pod1["field1"], ?pod2["field1"])
-//     Lt(?pod1["timestamp"], 1234567890)
+//     Equal(pod1["field1"], pod2["field1"])
+//     Lt(pod1["timestamp"], 1234567890)
 // )
 
 `;

--- a/apps/simple-zukyc/src/app/page.tsx
+++ b/apps/simple-zukyc/src/app/page.tsx
@@ -12,10 +12,10 @@ export default function Home() {
 
   const request = `
     REQUEST(
-      NotContains(?sanctions["sanctionList"], ?gov["idNumber"])
-      Lt(?gov["dateOfBirth"], 1169909388)
-      Equal(?pay["startDate"], 1706367566)
-      Equal(?gov["socialSecurityNumber"], ?pay["socialSecurityNumber"])
+      NotContains(sanctions["sanctionList"], gov["idNumber"])
+      Lt(gov["dateOfBirth"], 1169909388)
+      Equal(pay["startDate"], 1706367566)
+      Equal(gov["socialSecurityNumber"], pay["socialSecurityNumber"])
     )
     `;
 

--- a/core/models/src/lib.rs
+++ b/core/models/src/lib.rs
@@ -508,15 +508,15 @@ pub struct UpvoteRequest {
 pub fn get_publish_verification_predicate() -> String {
     r#"
         identity_verified(username, identity_pod) = AND(
-            Equal(?identity_pod["username"], ?username)
+            Equal(identity_pod["username"], username)
         )
 
         publish_verified(username, data, identity_server_pk, private: identity_pod, document_pod) = AND(
-            identity_verified(?username, ?identity_pod)
-            Equal(?document_pod["request_type"], "publish")
-            Equal(?document_pod["data"], ?data)
-            SignedBy(?document_pod, ?identity_pod["user_public_key"])
-            SignedBy(?identity_pod, ?identity_server_pk)
+            identity_verified(username, identity_pod)
+            Equal(document_pod["request_type"], "publish")
+            Equal(document_pod["data"], data)
+            SignedBy(document_pod, identity_pod["user_public_key"])
+            SignedBy(identity_pod, identity_server_pk)
         )
         "#.to_string()
 }
@@ -525,20 +525,20 @@ pub fn get_publish_verification_predicate() -> String {
 pub fn get_upvote_verification_predicate() -> String {
     r#"
         identity_verified(username, identity_pod) = AND(
-            Equal(?identity_pod["username"], ?username)
+            Equal(identity_pod["username"], username)
         )
 
         upvote_verified(content_hash, upvote_pod) = AND(
-            Equal(?upvote_pod["content_hash"], ?content_hash)
-            Equal(?upvote_pod["request_type"], "upvote")
+            Equal(upvote_pod["content_hash"], content_hash)
+            Equal(upvote_pod["request_type"], "upvote")
         )
 
         upvote_verification(username, content_hash, identity_server_pk, private: identity_pod, upvote_pod, upvote_pod_signer) = AND(
-            identity_verified(?username, ?identity_pod)
-            upvote_verified(?content_hash, ?upvote_pod)
-            SignedBy(?identity_pod, ?identity_server_pk)
-            SignedBy(?upvote_pod, ?upvote_pod_signer)
-            Equal(?identity_pod["user_public_key"], ?upvote_pod_signer)
+            identity_verified(username, identity_pod)
+            upvote_verified(content_hash, upvote_pod)
+            SignedBy(identity_pod, identity_server_pk)
+            SignedBy(upvote_pod, upvote_pod_signer)
+            Equal(identity_pod["user_public_key"], upvote_pod_signer)
         )
         "#.to_string()
 }
@@ -550,20 +550,20 @@ pub fn get_upvote_count_predicate(upvote_batch_id: Hash) -> String {
         use _, _, upvote_verification from 0x{id}
 
         upvote_count_base(count, content_hash, private: data_pod) = AND(
-            Equal(?count, 0)
-            Equal(?data_pod["content_hash"], ?content_hash)
+            Equal(count, 0)
+            Equal(data_pod["content_hash"], content_hash)
         )
 
         upvote_count_ind(count, content_hash, private: intermed, username, identity_server_pk) = AND(
-            upvote_count(?intermed, ?content_hash)
-            SumOf(?count, ?intermed, 1)
-            upvote_verification(?username, ?content_hash, ?identity_server_pk)
-            Lt(0, ?count)
+            upvote_count(intermed, content_hash)
+            SumOf(count, intermed, 1)
+            upvote_verification(username, content_hash, identity_server_pk)
+            Lt(0, count)
         )
 
         upvote_count(count, content_hash) = OR(
-            upvote_count_base(?count, ?content_hash)
-            upvote_count_ind(?count, ?content_hash)
+            upvote_count_base(count, content_hash)
+            upvote_count_ind(count, content_hash)
         )
         "#,
         id = upvote_batch_id.encode_hex::<String>(),

--- a/core/models/src/mainpod/delete.rs
+++ b/core/models/src/mainpod/delete.rs
@@ -26,20 +26,20 @@ use super::{MainPodError, MainPodResult};
 pub fn get_delete_verification_predicate() -> String {
     r#"
         identity_verified(username, identity_pod) = AND(
-            Equal(?identity_pod["username"], ?username)
+            Equal(identity_pod["username"], username)
         )
 
         document_verified(data, timestamp_pod, private: identity_pod, document_pod) = AND(
-            Equal(?document_pod["request_type"], "delete")
-            Equal(?document_pod["data"], ?data)
-            Equal(?document_pod["timestamp_pod"], ?timestamp_pod)
-            SignedBy(?document_pod, ?identity_pod["user_public_key"])
+            Equal(document_pod["request_type"], "delete")
+            Equal(document_pod["data"], data)
+            Equal(document_pod["timestamp_pod"], timestamp_pod)
+            SignedBy(document_pod, identity_pod["user_public_key"])
         )
 
         delete_verified(username, data, identity_server_pk, timestamp_pod, private: identity_pod, document_pod) = AND(
-            identity_verified(?username, ?identity_pod)
-            document_verified(?data, ?timestamp_pod)
-            SignedBy(?identity_pod, ?identity_server_pk)
+            identity_verified(username, identity_pod)
+            document_verified(data, timestamp_pod)
+            SignedBy(identity_pod, identity_server_pk)
         )
     "#.to_string()
 }

--- a/core/models/src/mainpod/publish.rs
+++ b/core/models/src/mainpod/publish.rs
@@ -165,15 +165,15 @@ mod tests {
 
         let query = r#"
         identity_verified(username, identity_pod) = AND(
-            Equal(?identity_pod["username"], ?username)
+            Equal(identity_pod["username"], username)
         )
 
         publish_verified(username, data, identity_server_pk, private: identity_pod, document_pod) = AND(
-            identity_verified(?username, ?identity_pod)
-            Equal(?document_pod["request_type"], "publish")
-            Equal(?document_pod["data"], ?data)
-            SignedBy(?document_pod, ?identity_pod["user_public_key"])
-            SignedBy(?identity_pod, ?identity_server_pk)
+            identity_verified(username, identity_pod)
+            Equal(document_pod["request_type"], "publish")
+            Equal(document_pod["data"], data)
+            SignedBy(document_pod, identity_pod["user_public_key"])
+            SignedBy(identity_pod, identity_server_pk)
         )
         
         REQUEST(

--- a/core/models/src/mainpod/upvote.rs
+++ b/core/models/src/mainpod/upvote.rs
@@ -446,20 +446,20 @@ mod tests {
         ).unwrap();
         let query = r#"
         identity_verified(username, identity_pod) = AND(
-            Equal(?identity_pod["username"], ?username)
+            Equal(identity_pod["username"], username)
         )
 
         upvote_verified(content_hash, upvote_pod) = AND(
-            Equal(?upvote_pod["content_hash"], ?content_hash)
-            Equal(?upvote_pod["request_type"], "upvote")
+            Equal(upvote_pod["content_hash"], content_hash)
+            Equal(upvote_pod["request_type"], "upvote")
         )
 
         upvote_verification(username, content_hash, identity_server_pk, private: identity_pod, upvote_pod, upvote_pod_signer) = AND(
-            identity_verified(?username, ?identity_pod)
-            upvote_verified(?content_hash, ?upvote_pod)
-            SignedBy(?identity_pod, ?identity_server_pk)
-            SignedBy(?upvote_pod, ?upvote_pod_signer)
-            Equal(?identity_pod["user_public_key"], ?upvote_pod_signer)
+            identity_verified(username, identity_pod)
+            upvote_verified(content_hash, upvote_pod)
+            SignedBy(identity_pod, identity_server_pk)
+            SignedBy(upvote_pod, upvote_pod_signer)
+            Equal(identity_pod["user_public_key"], upvote_pod_signer)
         )
         
 

--- a/core/models/tests/upvote_count_test.rs
+++ b/core/models/tests/upvote_count_test.rs
@@ -72,20 +72,20 @@ fn test_simple_upvote_count() {
     // Create a simple predicate that just does counting without verification
     let simple_predicate = r#"
     upvote_count_base(count, content_hash, private: data_pod) = AND(
-        Equal(?count, 0)
-        Equal(?data_pod["content_hash"], ?content_hash)
+        Equal(count, 0)
+        Equal(data_pod["content_hash"], content_hash)
     )
 
     upvote_count_ind(count, content_hash, private: data_pod, intermed) = AND(
-        upvote_count(?intermed, ?content_hash)
-        SumOf(?count, ?intermed, 1)
-        Equal(?data_pod["content_hash"], ?content_hash)
-        Lt(0, ?count)
+        upvote_count(intermed, content_hash)
+        SumOf(count, intermed, 1)
+        Equal(data_pod["content_hash"], content_hash)
+        Lt(0, count)
     )
 
     upvote_count(count, content_hash) = OR(
-        upvote_count_base(?count, ?content_hash)
-        upvote_count_ind(?count, ?content_hash)
+        upvote_count_base(count, content_hash)
+        upvote_count_ind(count, content_hash)
     )
     "#;
 

--- a/core/new_solver/src/handlers/contains.rs
+++ b/core/new_solver/src/handlers/contains.rs
@@ -379,13 +379,13 @@ mod tests {
         // Bind root and key via wildcards or literals; here we bind root as wildcard
         store.bindings.insert(0, Value::from(root));
         let handler = CopyContainsHandler;
-        let args = args_from("REQUEST(Contains(?R, \"k\", ?V))");
+        let args = args_from("REQUEST(Contains(R, \"k\", V))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
                 assert_eq!(alternatives.len(), 1);
                 let ch = &alternatives[0];
-                assert_eq!(ch.bindings[0].0, 1); // ?V index
+                assert_eq!(ch.bindings[0].0, 1); // V index
                 assert_eq!(ch.bindings[0].1, Value::from(7));
                 assert!(matches!(ch.op_tag, OpTag::CopyStatement { .. }));
             }
@@ -407,12 +407,12 @@ mod tests {
         let mut store = ConstraintStore::default();
         store.bindings.insert(0, Value::from(root));
         let handler = ContainsFromEntriesHandler;
-        let args = args_from("REQUEST(Contains(?R, \"k\", ?V))");
+        let args = args_from("REQUEST(Contains(R, \"k\", V))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { bindings, op_tag } => {
                 assert_eq!(bindings.len(), 1);
-                assert_eq!(bindings[0].0, 1); // ?V index
+                assert_eq!(bindings[0].0, 1); // V index
                 assert_eq!(bindings[0].1, Value::from(9));
                 assert!(matches!(op_tag, OpTag::GeneratedContains { .. }));
             }
@@ -445,7 +445,7 @@ mod tests {
         // Engine will prefer GeneratedContains when deduping; here we just check individual handler outputs are reasonable.
         let copy = CopyContainsHandler;
         let gen = ContainsFromEntriesHandler;
-        let args = args_from("REQUEST(Contains(?R, \"k\", ?V))");
+        let args = args_from("REQUEST(Contains(R, \"k\", V))");
         let r1 = copy.propagate(&args, &mut store.clone(), &edb);
         let r2 = gen.propagate(&args, &mut store.clone(), &edb);
         assert!(matches!(r1, PropagatorResult::Choices { .. }));

--- a/core/new_solver/src/handlers/equal.rs
+++ b/core/new_solver/src/handlers/equal.rs
@@ -285,7 +285,7 @@ mod tests {
 
     #[test]
     fn equal_from_entries_ak_v_generated_bound() {
-        // Equal(?R["k"], 1) with bound R and full dict containing (k -> 1)
+        // Equal(R["k"], 1) with bound R and full dict containing (k -> 1)
         // Build a real dictionary with {k:1}
         let params = Params::default();
         let dict = Dictionary::new(
@@ -297,11 +297,11 @@ mod tests {
         let edb = ImmutableEdbBuilder::new().add_full_dict(dict).build();
 
         let mut store = ConstraintStore::default();
-        // wildcard index is 0 for first ?R variable in a simple REQUEST
+        // wildcard index is 0 for first R variable in a simple REQUEST
         store.bindings.insert(0, Value::from(r));
 
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(?R[\"k\"], 1))");
+        let args = args_from("REQUEST(Equal(R[\"k\"], 1))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { op_tag, .. } => match op_tag {
@@ -337,7 +337,7 @@ mod tests {
         store.bindings.insert(0, Value::from(dict));
 
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(?R[\"k\"], 1))");
+        let args = args_from("REQUEST(Equal(R[\"k\"], 1))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { op_tag, .. } => match op_tag {
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     fn copy_equal_binds_wildcard_from_left_ak() {
-        // CopyEqual should bind ?X when ?R is bound and Equal(R["k"], 1) exists to copy
+        // CopyEqual should bind X when R is bound and Equal(R["k"], 1) exists to copy
         let params = Params::default();
         let dict = Dictionary::new(
             params.max_depth_mt_containers,
@@ -373,16 +373,16 @@ mod tests {
             .build();
 
         let mut store = ConstraintStore::default();
-        store.bindings.insert(0, Value::from(r)); // bind ?R
+        store.bindings.insert(0, Value::from(r)); // bind R
 
         let handler = CopyEqualHandler;
-        let args = args_from(r#"REQUEST(Equal(?R["k"], ?X))"#);
+        let args = args_from(r#"REQUEST(Equal(R["k"], X))"#);
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
                 assert_eq!(alternatives.len(), 1);
                 let ch = &alternatives[0];
-                assert_eq!(ch.bindings[0].0, 1); // ?X index
+                assert_eq!(ch.bindings[0].0, 1); // X index
                 assert_eq!(ch.bindings[0].1, Value::from(1));
                 match &ch.op_tag {
                     OpTag::CopyStatement { source } => assert_eq!(*source, src),
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn copy_equal_binds_wildcard_from_right_ak() {
-        // CopyEqual should bind ?X when ?R is bound and Equal(1, R["k"]) exists to copy
+        // CopyEqual should bind X when R is bound and Equal(1, R["k"]) exists to copy
         let params = Params::default();
         let dict = Dictionary::new(
             params.max_depth_mt_containers,
@@ -411,16 +411,16 @@ mod tests {
             .build();
 
         let mut store = ConstraintStore::default();
-        store.bindings.insert(1, Value::from(r)); // bind ?R (second wildcard)
+        store.bindings.insert(1, Value::from(r)); // bind R (second wildcard)
 
         let handler = CopyEqualHandler;
-        let args = args_from(r#"REQUEST(Equal(?X, ?R["k"]))"#);
+        let args = args_from(r#"REQUEST(Equal(X, R["k"]))"#);
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
                 assert_eq!(alternatives.len(), 1);
                 let ch = &alternatives[0];
-                assert_eq!(ch.bindings[0].0, 0); // ?X index
+                assert_eq!(ch.bindings[0].0, 0); // X index
                 assert_eq!(ch.bindings[0].1, Value::from(1));
                 match &ch.op_tag {
                     OpTag::CopyStatement { source } => assert_eq!(*source, src),
@@ -433,7 +433,7 @@ mod tests {
 
     #[test]
     fn equal_from_entries_ak_v_copied_unbound() {
-        // Equal(?R["k"], 1) with unbound R and only a copied Contains fact
+        // Equal(R["k"], 1) with unbound R and only a copied Contains fact
         let params = Params::default();
         let dict = Dictionary::new(
             params.max_depth_mt_containers,
@@ -451,7 +451,7 @@ mod tests {
 
         let mut store = ConstraintStore::default();
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(?R[\"k\"], 1))");
+        let args = args_from("REQUEST(Equal(R[\"k\"], 1))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
@@ -474,7 +474,7 @@ mod tests {
 
     #[test]
     fn equal_from_entries_v_ak_generated_unbound() {
-        // Equal(1, ?R["k"]) unbound R, full dict
+        // Equal(1, R["k"]) unbound R, full dict
         let params = Params::default();
         let dict = Dictionary::new(
             params.max_depth_mt_containers,
@@ -485,7 +485,7 @@ mod tests {
         let edb = ImmutableEdbBuilder::new().add_full_dict(dict).build();
         let mut store = ConstraintStore::default();
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(1, ?R[\"k\"]))");
+        let args = args_from("REQUEST(Equal(1, R[\"k\"]))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
@@ -504,7 +504,7 @@ mod tests {
 
     #[test]
     fn equal_from_entries_v_ak_copied_unbound() {
-        // Equal(1, ?R["k"]) unbound R, only copied Contains
+        // Equal(1, R["k"]) unbound R, only copied Contains
         let params = Params::default();
         let dict = Dictionary::new(
             params.max_depth_mt_containers,
@@ -522,7 +522,7 @@ mod tests {
 
         let mut store = ConstraintStore::default();
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(1, ?R[\"k\"]))");
+        let args = args_from("REQUEST(Equal(1, R[\"k\"]))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
@@ -541,7 +541,7 @@ mod tests {
 
     #[test]
     fn equal_from_entries_ak_ak_one_bound_enumerate_generated() {
-        // Equal(?L["a"], ?R["b"]) with left bound (value 7), right unbound; enumerate right from full dict
+        // Equal(L["a"], R["b"]) with left bound (value 7), right unbound; enumerate right from full dict
         let params = Params::default();
         // Left dict has a:7 (can be copied or full; contains_value prefers copied if both)
         let dict_l = Dictionary::new(
@@ -568,7 +568,7 @@ mod tests {
         store.bindings.insert(0, Value::from(rl)); // bind left
 
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(?L[\"a\"], ?R[\"b\"]))");
+        let args = args_from("REQUEST(Equal(L[\"a\"], R[\"b\"]))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
@@ -600,7 +600,7 @@ mod tests {
 
     #[test]
     fn equal_from_entries_ak_ak_one_bound_enumerate_copied() {
-        // Equal(?L["a"], ?R["b"]) with left bound (value 7), right unbound; enumerate right from copied Contains
+        // Equal(L["a"], R["b"]) with left bound (value 7), right unbound; enumerate right from copied Contains
         let params = Params::default();
         // Left dict has a:7
         let dict_l = Dictionary::new(
@@ -633,7 +633,7 @@ mod tests {
         store.bindings.insert(0, Value::from(rl)); // bind left
 
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(?L[\"a\"], ?R[\"b\"]))");
+        let args = args_from("REQUEST(Equal(L[\"a\"], R[\"b\"]))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
@@ -669,7 +669,7 @@ mod tests {
         let edb = ImmutableEdbBuilder::new().build();
         let mut store = ConstraintStore::default();
         let handler = EqualFromEntriesHandler;
-        let args = args_from(r#"REQUEST(Equal(?L["a"], ?R["b"]))"#);
+        let args = args_from(r#"REQUEST(Equal(L["a"], R["b"]))"#);
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Suspend { on } => {
@@ -682,7 +682,7 @@ mod tests {
 
     #[test]
     fn equal_from_entries_negative_no_match() {
-        // AK–V: query Equal(?R["k"], 1) but only have k:2 in full dict → no choices
+        // AK–V: query Equal(R["k"], 1) but only have k:2 in full dict → no choices
         let params = Params::default();
         let dict = Dictionary::new(
             params.max_depth_mt_containers,
@@ -693,7 +693,7 @@ mod tests {
 
         let mut store = ConstraintStore::default();
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(?R[\"k\"], 1))");
+        let args = args_from("REQUEST(Equal(R[\"k\"], 1))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             // Under-constrained: unbound root, no matches → Suspend on root wildcard
@@ -722,7 +722,7 @@ mod tests {
         let mut store2 = ConstraintStore::default();
         store2.bindings.insert(0, Value::from(rl));
         store2.bindings.insert(1, Value::from(rr));
-        let args2 = args_from("REQUEST(Equal(?L[\"a\"], ?R[\"b\"]))");
+        let args2 = args_from("REQUEST(Equal(L[\"a\"], R[\"b\"]))");
         let res2 = handler.propagate(&args2, &mut store2, &edb2);
         match res2 {
             PropagatorResult::Contradiction => {}
@@ -732,7 +732,7 @@ mod tests {
 
     #[test]
     fn equal_from_entries_ak_ak_both_bound_equal_mixed_sources() {
-        // Equal(?L["a"], ?R["b"]) with both roots bound, values equal; left copied, right generated
+        // Equal(L["a"], R["b"]) with both roots bound, values equal; left copied, right generated
         let params = Params::default();
         let dict_l = Dictionary::new(
             params.max_depth_mt_containers,
@@ -757,7 +757,7 @@ mod tests {
         store.bindings.insert(1, Value::from(rr));
 
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(?L[\"a\"], ?R[\"b\"]))");
+        let args = args_from("REQUEST(Equal(L[\"a\"], R[\"b\"]))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { op_tag, .. } => match op_tag {
@@ -780,7 +780,7 @@ mod tests {
 
     #[test]
     fn equal_from_entries_ak_wildcard_bind_value_when_root_bound() {
-        // Equal(?R["k"], ?X) with bound R and full dict containing (k -> 1) binds ?X=1
+        // Equal(R["k"], X) with bound R and full dict containing (k -> 1) binds ?X=1
         let params = Params::default();
         let dict = Dictionary::new(
             params.max_depth_mt_containers,
@@ -791,11 +791,11 @@ mod tests {
         let edb = ImmutableEdbBuilder::new().add_full_dict(dict).build();
 
         let mut store = ConstraintStore::default();
-        // wildcard index 0 for ?R, 1 for ?X in this template order
+        // wildcard index 0 for R, 1 for X in this template order
         store.bindings.insert(0, Value::from(r));
 
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(?R[\"k\"], ?X))");
+        let args = args_from("REQUEST(Equal(R[\"k\"], X))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { bindings, op_tag } => {
@@ -816,11 +816,11 @@ mod tests {
 
     #[test]
     fn equal_from_entries_ak_wildcard_unbound_suspends() {
-        // Equal(?R["k"], ?X) with both unbound should suspend (no guessing)
+        // Equal(R["k"], X) with both unbound should suspend (no guessing)
         let edb = ImmutableEdbBuilder::new().build();
         let mut store = ConstraintStore::default();
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(?R[\"k\"], ?X))");
+        let args = args_from("REQUEST(Equal(R[\"k\"], X))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Suspend { on } => {
@@ -833,7 +833,7 @@ mod tests {
 
     #[test]
     fn equal_from_entries_wildcard_ak_bound_value_enumerates() {
-        // Equal(?X, ?R["k"]) with ?X bound to 1 enumerates roots with k->1
+        // Equal(X, R["k"]) with X bound to 1 enumerates roots with k->1
         let params = Params::default();
         let dict = Dictionary::new(
             params.max_depth_mt_containers,
@@ -843,10 +843,10 @@ mod tests {
         let r = dict.commitment();
         let edb = ImmutableEdbBuilder::new().add_full_dict(dict).build();
         let mut store = ConstraintStore::default();
-        // ?X is first wildcard (index 0), ?R is index 1
+        // X is first wildcard (index 0), R is index 1
         store.bindings.insert(0, Value::from(1));
         let handler = EqualFromEntriesHandler;
-        let args = args_from("REQUEST(Equal(?X, ?R[\"k\"]))");
+        let args = args_from("REQUEST(Equal(X, R[\"k\"]))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {

--- a/core/new_solver/src/handlers/hashof.rs
+++ b/core/new_solver/src/handlers/hashof.rs
@@ -190,7 +190,7 @@ mod tests {
         let mut store = ConstraintStore::default();
         let handler = HashOfFromEntriesHandler;
 
-        let args = args_from("REQUEST(HashOf(?X, \"hello\", \"world\"))");
+        let args = args_from("REQUEST(HashOf(X, \"hello\", \"world\"))");
         let result = handler.propagate(&args, &mut store, &edb);
 
         match result {
@@ -223,9 +223,9 @@ mod tests {
         let mut store = ConstraintStore::default();
         let handler = HashOfFromEntriesHandler;
 
-        let args = args_from("REQUEST(HashOf(\"some_hash\", ?Y, \"world\"))");
+        let args = args_from("REQUEST(HashOf(\"some_hash\", Y, \"world\"))");
         let result = handler.propagate(&args, &mut store, &edb);
-        // ?Y is the first wildcard, so it gets index 0
+        // Y is the first wildcard, so it gets index 0
         assert!(matches!(result, PropagatorResult::Suspend { on } if on == vec![0]));
     }
 
@@ -235,9 +235,9 @@ mod tests {
         let mut store = ConstraintStore::default();
         let handler = HashOfFromEntriesHandler;
 
-        let args = args_from("REQUEST(HashOf(\"some_hash\", \"hello\", ?Z))");
+        let args = args_from("REQUEST(HashOf(\"some_hash\", \"hello\", Z))");
         let result = handler.propagate(&args, &mut store, &edb);
-        // ?Z is the first wildcard, so it gets index 0
+        // Z is the first wildcard, so it gets index 0
         assert!(matches!(result, PropagatorResult::Suspend { on } if on == vec![0]));
     }
 
@@ -290,7 +290,7 @@ mod tests {
         let mut store = ConstraintStore::default();
         let handler = CopyHashOfHandler;
         // Match first two, bind third
-        let args = args_from("REQUEST(HashOf(?X, \"hello\", \"world\"))");
+        let args = args_from("REQUEST(HashOf(X, \"hello\", \"world\"))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {

--- a/core/new_solver/src/handlers/lt.rs
+++ b/core/new_solver/src/handlers/lt.rs
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn lt_from_entries_ak_lit_generated() {
-        // Lt(?R["k"], 10) with bound root and full dict k:7
+        // Lt(R["k"], 10) with bound root and full dict k:7
         let params = Params::default();
         let dict = Dictionary::new(
             params.max_depth_mt_containers,
@@ -88,7 +88,7 @@ mod tests {
         let mut store = ConstraintStore::default();
         store.bindings.insert(0, Value::from(root));
         let handler = BinaryComparisonHandler::new(|a, b| a < b, "Lt");
-        let args = args_from("REQUEST(Lt(?R[\"k\"], 10))");
+        let args = args_from("REQUEST(Lt(R[\"k\"], 10))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { op_tag, .. } => match op_tag {
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn lt_from_entries_ak_ak_both_bound() {
-        // Lt(?L["a"], ?R["b"]) with both bound and 3 < 5
+        // Lt(L["a"], R["b"]) with both bound and 3 < 5
         let params = Params::default();
         let dl = Dictionary::new(
             params.max_depth_mt_containers,
@@ -127,7 +127,7 @@ mod tests {
         store.bindings.insert(0, Value::from(rl));
         store.bindings.insert(1, Value::from(rr));
         let handler = BinaryComparisonHandler::new(|a, b| a < b, "Lt");
-        let args = args_from(r#"REQUEST(Lt(?L["a"], ?R["b"]))"#);
+        let args = args_from(r#"REQUEST(Lt(L["a"], R["b"]))"#);
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { op_tag, .. } => match op_tag {
@@ -140,11 +140,11 @@ mod tests {
 
     #[test]
     fn lt_from_entries_suspend_unbound() {
-        // Lt(?L["a"], 10) with unbound left root should suspend
+        // Lt(L["a"], 10) with unbound left root should suspend
         let edb = ImmutableEdbBuilder::new().build();
         let mut store = ConstraintStore::default();
         let handler = BinaryComparisonHandler::new(|a, b| a < b, "Lt");
-        let args = args_from("REQUEST(Lt(?L[\"a\"], 10))");
+        let args = args_from("REQUEST(Lt(L[\"a\"], 10))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Suspend { on } => assert!(on.contains(&0)),
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn copy_lt_binds_value_from_left_ak_when_root_bound() {
-        // Given Lt(R["k"], 10) in EDB, CopyLt should bind ?X when ?R bound
+        // Given Lt(R["k"], 10) in EDB, CopyLt should bind X when R bound
         let params = Params::default();
         let dict = Dictionary::new(
             params.max_depth_mt_containers,
@@ -174,15 +174,15 @@ mod tests {
             .build();
 
         let mut store = ConstraintStore::default();
-        store.bindings.insert(0, Value::from(r)); // ?R
+        store.bindings.insert(0, Value::from(r)); // R
         let handler = CopyLtHandler;
-        let args = args_from(r#"REQUEST(Lt(?R["k"], ?X))"#);
+        let args = args_from(r#"REQUEST(Lt(R["k"], X))"#);
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
                 assert_eq!(alternatives.len(), 1);
                 let ch = &alternatives[0];
-                assert_eq!(ch.bindings[0].0, 1); // ?X index
+                assert_eq!(ch.bindings[0].0, 1); // X index
                 assert_eq!(ch.bindings[0].1, Value::from(10));
             }
             other => panic!("unexpected result: {other:?}"),
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn copy_lt_binds_root_from_right_ak_when_value_bound() {
-        // Given Lt(10, R["k"]) in EDB, CopyLt should bind ?R when ?X bound
+        // Given Lt(10, R["k"]) in EDB, CopyLt should bind R when X bound
         let params = Params::default();
         let dict = Dictionary::new(
             params.max_depth_mt_containers,
@@ -211,9 +211,9 @@ mod tests {
             .build();
 
         let mut store = ConstraintStore::default();
-        store.bindings.insert(0, Value::from(10)); // ?X left
+        store.bindings.insert(0, Value::from(10)); // X left
         let handler = CopyLtHandler;
-        let args = args_from(r#"REQUEST(Lt(?X, ?R["k"]))"#);
+        let args = args_from(r#"REQUEST(Lt(X, R["k"]))"#);
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
@@ -228,7 +228,7 @@ mod tests {
 
     #[test]
     fn copy_lt_binds_both_wildcards_from_vv_fact() {
-        // Lt(?X, ?Y) should bind both from Lt(3, 5) fact
+        // Lt(X, Y) should bind both from Lt(3, 5) fact
         let src = PodRef(test_helpers::root("s"));
         let edb = ImmutableEdbBuilder::new()
             .add_statement_for_test(Statement::Lt(3.into(), 5.into()), src.clone())
@@ -236,7 +236,7 @@ mod tests {
 
         let mut store = ConstraintStore::default();
         let handler = CopyLtHandler;
-        let args = args_from("REQUEST(Lt(?X, ?Y))");
+        let args = args_from("REQUEST(Lt(X, Y))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn copy_lt_binds_one_wildcard_from_vv_partial() {
-        // Lt(?X, 5) binds ?X from Lt(3,5); Lt(3, ?Y) binds ?Y from Lt(3,5)
+        // Lt(X, 5) binds X from Lt(3,5); Lt(3, Y) binds Y from Lt(3,5)
         let src = PodRef(test_helpers::root("s"));
         let edb = ImmutableEdbBuilder::new()
             .add_statement_for_test(Statement::Lt(3.into(), 5.into()), src.clone())
@@ -263,7 +263,7 @@ mod tests {
 
         let mut store = ConstraintStore::default();
         let handler = CopyLtHandler;
-        let args1 = args_from("REQUEST(Lt(?X, 5))");
+        let args1 = args_from("REQUEST(Lt(X, 5))");
         let res1 = handler.propagate(&args1, &mut store, &edb);
         match res1 {
             PropagatorResult::Choices { alternatives } => {
@@ -275,7 +275,7 @@ mod tests {
             other => panic!("unexpected result: {other:?}"),
         }
 
-        let args2 = args_from("REQUEST(Lt(3, ?Y))");
+        let args2 = args_from("REQUEST(Lt(3, Y))");
         let res2 = handler.propagate(&args2, &mut store, &edb);
         match res2 {
             PropagatorResult::Choices { alternatives } => {

--- a/core/new_solver/src/handlers/lteq.rs
+++ b/core/new_solver/src/handlers/lteq.rs
@@ -88,7 +88,7 @@ mod tests {
         let mut store = ConstraintStore::default();
         store.bindings.insert(0, Value::from(root));
         let handler = BinaryComparisonHandler::new(|a, b| a <= b, "LtEq");
-        let args = args_from("REQUEST(LtEq(?R[\"k\"], 7))");
+        let args = args_from("REQUEST(LtEq(R[\"k\"], 7))");
         let res = handler.propagate(&args, &mut store, &edb);
         assert!(matches!(
             res,
@@ -101,7 +101,7 @@ mod tests {
 
     #[test]
     fn lteq_from_entries_ak_ak_both_bound() {
-        // LtEq(?L["a"], ?R["b"]) with both AK roots bound; 3 <= 5 should entail with two premises
+        // LtEq(L["a"], R["b"]) with both AK roots bound; 3 <= 5 should entail with two premises
         let params = Params::default();
         let dl = Dictionary::new(
             params.max_depth_mt_containers,
@@ -125,7 +125,7 @@ mod tests {
         store.bindings.insert(1, Value::from(rr));
 
         let handler = BinaryComparisonHandler::new(|a, b| a <= b, "LtEq");
-        let args = args_from("REQUEST(LtEq(?L[\"a\"], ?R[\"b\"]))");
+        let args = args_from("REQUEST(LtEq(L[\"a\"], R[\"b\"]))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { op_tag, .. } => match op_tag {
@@ -138,11 +138,11 @@ mod tests {
 
     #[test]
     fn lteq_from_entries_suspend_unbound() {
-        // LtEq(?R["k"], 7) with unbound root should suspend
+        // LtEq(R["k"], 7) with unbound root should suspend
         let edb = ImmutableEdbBuilder::new().build();
         let mut store = ConstraintStore::default();
         let handler = BinaryComparisonHandler::new(|a, b| a <= b, "LtEq");
-        let args = args_from(r#"REQUEST(LtEq(?R["k"], 7))"#);
+        let args = args_from(r#"REQUEST(LtEq(R["k"], 7))"#);
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Suspend { on } => assert!(on.contains(&0)),
@@ -170,7 +170,7 @@ mod tests {
 
         let mut store = ConstraintStore::default();
         let handler = CopyLtEqHandler;
-        let args = args_from("REQUEST(LtEq(?X, ?Y))");
+        let args = args_from("REQUEST(LtEq(X, Y))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
@@ -197,7 +197,7 @@ mod tests {
         let mut store = ConstraintStore::default();
         let handler = CopyLtEqHandler;
         // Bind right from left literal
-        let args1 = args_from("REQUEST(LtEq(3, ?Y))");
+        let args1 = args_from("REQUEST(LtEq(3, Y))");
         let res1 = handler.propagate(&args1, &mut store, &edb);
         match res1 {
             PropagatorResult::Choices { alternatives } => {
@@ -210,7 +210,7 @@ mod tests {
         }
 
         // Bind left from right literal
-        let args2 = args_from("REQUEST(LtEq(?X, 5))");
+        let args2 = args_from("REQUEST(LtEq(X, 5))");
         let res2 = handler.propagate(&args2, &mut store, &edb);
         match res2 {
             PropagatorResult::Choices { alternatives } => {
@@ -245,7 +245,7 @@ mod tests {
 
         let mut store = ConstraintStore::default();
         let handler = CopyLtEqHandler;
-        let args = args_from("REQUEST(LtEq(?R[\"k\"], 10))");
+        let args = args_from("REQUEST(LtEq(R[\"k\"], 10))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
@@ -277,7 +277,7 @@ mod tests {
 
         let mut store = ConstraintStore::default();
         let handler = CopyLtEqHandler;
-        let args = args_from("REQUEST(LtEq(5, ?R[\"k\"]))");
+        let args = args_from("REQUEST(LtEq(5, R[\"k\"]))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {

--- a/core/new_solver/src/handlers/maxof.rs
+++ b/core/new_solver/src/handlers/maxof.rs
@@ -72,7 +72,7 @@ mod tests {
             |a, b| if a >= b { Some(a) } else { None },
             "MaxOf",
         );
-        let args = args_from("REQUEST(MaxOf(?X, 3, 7))");
+        let args = args_from("REQUEST(MaxOf(X, 3, 7))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { bindings, .. } => {
@@ -128,8 +128,8 @@ mod tests {
             |a, b| if a >= b { Some(a) } else { None },
             "MaxOf",
         );
-        // MaxOf(7, ?B, 3): max(B, 3) = 7, so B = 7
-        let args = args_from("REQUEST(MaxOf(7, ?B, 3))");
+        // MaxOf(7, B, 3): max(B, 3) = 7, so B = 7
+        let args = args_from("REQUEST(MaxOf(7, B, 3))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { bindings, .. } => {
@@ -149,8 +149,8 @@ mod tests {
             |a, b| if a >= b { Some(a) } else { None },
             "MaxOf",
         );
-        // MaxOf(7, 3, ?C): max(3, C) = 7, so C = 7
-        let args = args_from("REQUEST(MaxOf(7, 3, ?C))");
+        // MaxOf(7, 3, C): max(3, C) = 7, so C = 7
+        let args = args_from("REQUEST(MaxOf(7, 3, C))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { bindings, .. } => {
@@ -170,8 +170,8 @@ mod tests {
             |a, b| if a >= b { Some(a) } else { None },
             "MaxOf",
         );
-        // MaxOf(3, ?B, 7): max(B, 7) = 3, impossible since max must be >= 7
-        let args = args_from("REQUEST(MaxOf(3, ?B, 7))");
+        // MaxOf(3, B, 7): max(B, 7) = 3, impossible since max must be >= 7
+        let args = args_from("REQUEST(MaxOf(3, B, 7))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Contradiction => {}
@@ -189,8 +189,8 @@ mod tests {
             |a, b| if a >= b { Some(a) } else { None },
             "MaxOf",
         );
-        // MaxOf(3, 7, ?C): max(7, C) = 3, impossible since max must be >= 7
-        let args = args_from("REQUEST(MaxOf(3, 7, ?C))");
+        // MaxOf(3, 7, C): max(7, C) = 3, impossible since max must be >= 7
+        let args = args_from("REQUEST(MaxOf(3, 7, C))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Contradiction => {}
@@ -207,7 +207,7 @@ mod tests {
         let mut store = ConstraintStore::default();
         let handler = CopyMaxOfHandler;
         // Match first two, bind third
-        let args = args_from("REQUEST(MaxOf(7, 3, ?Z))");
+        let args = args_from("REQUEST(MaxOf(7, 3, Z))");
 
         let res = handler.propagate(&args, &mut store, &edb);
         match res {

--- a/core/new_solver/src/handlers/not_contains.rs
+++ b/core/new_solver/src/handlers/not_contains.rs
@@ -194,7 +194,7 @@ mod tests {
             .build();
         let mut store = ConstraintStore::default();
         let handler = CopyNotContainsHandler;
-        let args = args_from("REQUEST(NotContains(?R, \"missing\"))");
+        let args = args_from("REQUEST(NotContains(R, \"missing\"))");
         match handler.propagate(&args, &mut store, &edb) {
             PropagatorResult::Choices { alternatives } => {
                 assert!(alternatives.iter().any(|ch| ch
@@ -219,7 +219,7 @@ mod tests {
         let mut store = ConstraintStore::default();
         store.bindings.insert(0, Value::from(r));
         let handler = NotContainsFromEntriesHandler;
-        let args = args_from("REQUEST(NotContains(?R, \"missing\"))");
+        let args = args_from("REQUEST(NotContains(R, \"missing\"))");
         match handler.propagate(&args, &mut store, &edb) {
             PropagatorResult::Entailed { .. } => {}
             other => panic!("unexpected: {other:?}"),
@@ -239,7 +239,7 @@ mod tests {
         let mut store = ConstraintStore::default();
         store.bindings.insert(0, Value::from(r));
         let handler = NotContainsFromEntriesHandler;
-        let args = args_from("REQUEST(NotContains(?R, \"y\"))");
+        let args = args_from("REQUEST(NotContains(R, \"y\"))");
         match handler.propagate(&args, &mut store, &edb) {
             PropagatorResult::Contradiction => {}
             other => panic!("unexpected: {other:?}"),
@@ -251,7 +251,7 @@ mod tests {
         let edb = ImmutableEdbBuilder::new().build();
         let mut store = ConstraintStore::default();
         let handler = NotContainsFromEntriesHandler;
-        let args = args_from("REQUEST(NotContains(?R, \"k\"))");
+        let args = args_from("REQUEST(NotContains(R, \"k\"))");
         match handler.propagate(&args, &mut store, &edb) {
             PropagatorResult::Suspend { on } => assert!(on.contains(&0)),
             other => panic!("unexpected: {other:?}"),

--- a/core/new_solver/src/handlers/productof.rs
+++ b/core/new_solver/src/handlers/productof.rs
@@ -68,7 +68,7 @@ mod tests {
             |a, b| if b != 0 { a.checked_div(b) } else { None },
             "ProductOf",
         );
-        let args = args_from("REQUEST(ProductOf(?X, 3, 4))");
+        let args = args_from("REQUEST(ProductOf(X, 3, 4))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { bindings, .. } => {
@@ -120,7 +120,7 @@ mod tests {
             },
             "ProductOf",
         );
-        let args = args_from("REQUEST(ProductOf(7, 3, ?Z))");
+        let args = args_from("REQUEST(ProductOf(7, 3, Z))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Contradiction => {}

--- a/core/new_solver/src/handlers/publickeyof.rs
+++ b/core/new_solver/src/handlers/publickeyof.rs
@@ -191,13 +191,13 @@ mod tests {
         store.bindings.insert(0, Value::from(sk));
 
         let handler = PublicKeyOfHandler;
-        let args = args_from("REQUEST(PublicKeyOf(?SK, ?PK))");
+        let args = args_from("REQUEST(PublicKeyOf(SK, PK))");
         let res = handler.propagate(&args, &mut store, &edb);
 
         match res {
             PropagatorResult::Entailed { bindings, op_tag } => {
                 assert_eq!(bindings.len(), 1);
-                assert_eq!(bindings[0].0, 1); // ?PK index
+                assert_eq!(bindings[0].0, 1); // PK index
                 assert_eq!(bindings[0].1, pk_val);
                 assert!(matches!(op_tag, OpTag::FromLiterals));
             }
@@ -217,13 +217,13 @@ mod tests {
         store.bindings.insert(1, pk_val.clone());
 
         let handler = PublicKeyOfHandler;
-        let args = args_from("REQUEST(PublicKeyOf(?SK, ?PK))");
+        let args = args_from("REQUEST(PublicKeyOf(SK, PK))");
         let res = handler.propagate(&args, &mut store, &edb);
 
         match res {
             PropagatorResult::Entailed { bindings, op_tag } => {
                 assert_eq!(bindings.len(), 1);
-                assert_eq!(bindings[0].0, 0); // ?SK index
+                assert_eq!(bindings[0].0, 0); // SK index
                 assert_eq!(bindings[0].1, sk_val);
                 assert!(matches!(op_tag, OpTag::FromLiterals));
             }

--- a/core/new_solver/src/handlers/signed_by.rs
+++ b/core/new_solver/src/handlers/signed_by.rs
@@ -206,7 +206,7 @@ mod tests {
         store.bindings.insert(1, Value::from(pk));
 
         let handler = SignedByHandler;
-        let args = args_from("REQUEST(SignedBy(?R, ?PK))");
+        let args = args_from("REQUEST(SignedBy(R, PK))");
 
         let res = handler.propagate(&args, &mut store, &edb);
         assert!(matches!(res, PropagatorResult::Entailed { .. }));
@@ -231,7 +231,7 @@ mod tests {
         store.bindings.insert(1, Value::from(pk2));
 
         let handler = SignedByHandler;
-        let args = args_from("REQUEST(SignedBy(?R, ?PK))");
+        let args = args_from("REQUEST(SignedBy(R, PK))");
 
         let res = handler.propagate(&args, &mut store, &edb);
         assert!(matches!(res, PropagatorResult::Contradiction));
@@ -254,13 +254,13 @@ mod tests {
         store.bindings.insert(0, Value::from(root));
 
         let handler = SignedByHandler;
-        let args = args_from("REQUEST(SignedBy(?R, ?PK))");
+        let args = args_from("REQUEST(SignedBy(R, PK))");
 
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { bindings, .. } => {
                 assert_eq!(bindings.len(), 1);
-                assert_eq!(bindings[0].0, 1); // ?PK index
+                assert_eq!(bindings[0].0, 1); // PK index
                 assert_eq!(bindings[0].1, Value::from(pk));
             }
             other => panic!("Unexpected result: {other:?}"),
@@ -272,14 +272,14 @@ mod tests {
         let edb = ImmutableEdbBuilder::new().build();
         let mut store = ConstraintStore::default();
         let handler = SignedByHandler;
-        let args = args_from("REQUEST(SignedBy(?R, ?PK))");
+        let args = args_from("REQUEST(SignedBy(R, PK))");
 
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Suspend { on } => {
                 assert_eq!(on.len(), 2);
-                assert!(on.contains(&0)); // ?R
-                assert!(on.contains(&1)); // ?PK
+                assert!(on.contains(&0)); // R
+                assert!(on.contains(&1)); // PK
             }
             other => panic!("Unexpected result: {other:?}"),
         }

--- a/core/new_solver/src/handlers/sumof.rs
+++ b/core/new_solver/src/handlers/sumof.rs
@@ -72,7 +72,7 @@ mod tests {
             |a, b| Some(a - b),
             "SumOf",
         );
-        let args = args_from("REQUEST(SumOf(?X, 3, 4))");
+        let args = args_from("REQUEST(SumOf(X, 3, 4))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { bindings, .. } => {
@@ -105,7 +105,7 @@ mod tests {
             |a, b| Some(a - b),
             "SumOf",
         );
-        let args = args_from("REQUEST(SumOf(?R[\"a\"], 3, 4))");
+        let args = args_from("REQUEST(SumOf(R[\"a\"], 3, 4))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {
@@ -154,7 +154,7 @@ mod tests {
             |a, b| Some(a - b),
             "SumOf",
         );
-        let args = args_from("REQUEST(SumOf(7, ?A[\"x\"], ?B[\"y\"]))");
+        let args = args_from("REQUEST(SumOf(7, A[\"x\"], B[\"y\"]))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Entailed { op_tag, .. } => match op_tag {
@@ -174,7 +174,7 @@ mod tests {
         let mut store = ConstraintStore::default();
         let handler = CopySumOfHandler;
         // Match first two, bind third
-        let args = args_from("REQUEST(SumOf(15, 5, ?Z))");
+        let args = args_from("REQUEST(SumOf(15, 5, Z))");
         let res = handler.propagate(&args, &mut store, &edb);
         match res {
             PropagatorResult::Choices { alternatives } => {

--- a/core/new_solver/tests/ethdos.rs
+++ b/core/new_solver/tests/ethdos.rs
@@ -41,38 +41,38 @@ fn engine_ethdos_end_to_end() -> Result<(), String> {
     /*
     eth_dos_batch:
         eth_friend(src, dst, private: attestation) = AND(
-            SignedBy(?attestation, ?src)
-            Contains(?attestation, "attestation", ?dst)
+            SignedBy(attestation, src)
+            Contains(attestation, "attestation", dst)
         )
 
         eth_dos_base(src, dst, distance) = AND(
-            Equal(?src, ?dst)
-            Equal(?distance, 0)
+            Equal(src, dst)
+            Equal(distance, 0)
         )
 
         eth_dos_ind(src, dst, distance, private: shorter_distance, intermed) = AND(
-            eth_dos(?src, ?intermed, ?shorter_distance)
-            SumOf(?distance, ?shorter_distance, 1)
-            eth_friend(?intermed, ?dst)
+            eth_dos(src, intermed, shorter_distance)
+            SumOf(distance, shorter_distance, 1)
+            eth_friend(intermed, dst)
         )
 
         eth_dos(src, dst, distance) = OR(
-            eth_dos_base(?src, ?dst, ?distance)
-            eth_dos_ind(?src, ?dst, ?distance)
+            eth_dos_base(src, dst, distance)
+            eth_dos_ind(src, dst, distance)
         )
     */
 
     let reg = OpRegistry::default();
 
     /******************************************************************************
-     * Request: eth_dos(alice, alice, ?Distance)
+     * Request: eth_dos(alice, alice, Distance)
      ******************************************************************************/
     let req1 = format!(
         r#"
   use _, _, _, eth_dos from 0x{}
 
   REQUEST(
-      eth_dos(PublicKey({}), PublicKey({}), ?Distance)
+      eth_dos(PublicKey({}), PublicKey({}), Distance)
   )
   "#,
         batch.id().encode_hex::<String>(),
@@ -112,7 +112,7 @@ fn engine_ethdos_end_to_end() -> Result<(), String> {
     pod.pod.verify().unwrap();
 
     /******************************************************************************
-     * Request: eth_dos(alice, bob, ?Distance)
+     * Request: eth_dos(alice, bob, Distance)
      ******************************************************************************/
 
     let edb_builder = edb::ImmutableEdbBuilder::new();
@@ -126,7 +126,7 @@ fn engine_ethdos_end_to_end() -> Result<(), String> {
     use _, _, _, eth_dos from 0x{}
   
     REQUEST(
-        eth_dos(PublicKey({}), PublicKey({}), ?Distance)
+        eth_dos(PublicKey({}), PublicKey({}), Distance)
     )
     "#,
         batch.id().encode_hex::<String>(),
@@ -163,7 +163,7 @@ fn engine_ethdos_end_to_end() -> Result<(), String> {
     pod.pod.verify().unwrap();
 
     /******************************************************************************
-     * Request: eth_dos(alice, charlie, ?Distance)
+     * Request: eth_dos(alice, charlie, Distance)
      ******************************************************************************/
 
     let edb_builder = edb::ImmutableEdbBuilder::new();
@@ -182,7 +182,7 @@ fn engine_ethdos_end_to_end() -> Result<(), String> {
     use _, _, _, eth_dos from 0x{}
   
     REQUEST(
-        eth_dos(PublicKey({}), PublicKey({}), ?Distance)
+        eth_dos(PublicKey({}), PublicKey({}), Distance)
     )
     "#,
         batch.id().encode_hex::<String>(),

--- a/core/new_solver/tests/other.rs
+++ b/core/new_solver/tests/other.rs
@@ -21,7 +21,7 @@ fn test_literal_dict() -> Result<(), String> {
 
     let req1 = r#"
 init_membership(state) = AND(
-    DictContains(?state, "test", 0)
+    DictContains(state, "test", 0)
 )
 
 REQUEST(

--- a/core/solver/notes/arithmetic-datalog.md
+++ b/core/solver/notes/arithmetic-datalog.md
@@ -8,14 +8,14 @@ The POD2 solver encountered infinite loops when evaluating recursive predicates 
 
 ```
 upvote_count_ind(count, content_hash, private: data_pod, intermed) = AND(
-    upvote_count(?intermed, ?content_hash)
-    SumOf(?count, ?intermed, 1)
-    Equal(?data_pod["content_hash"], ?content_hash)
-    Lt(0, ?count)  // Should prevent recursion when count <= 0
+    upvote_count(intermed, content_hash)
+    SumOf(count, intermed, 1)
+    Equal(data_pod["content_hash"], content_hash)
+    Lt(0, count)  // Should prevent recursion when count <= 0
 )
 ```
 
-**Expected behavior**: Recursion should stop when `count <= 0` due to the `Lt(0, ?count)` constraint.
+**Expected behavior**: Recursion should stop when `count <= 0` due to the `Lt(0, count)` constraint.
 
 **Actual behavior**: Infinite recursion continues with negative count values: `1 → 0 → -1 → -2 → -3 → ...`
 
@@ -78,21 +78,21 @@ fn should_generate_magic_goal(
 
 #### 1. SumOf with Two Free Variables
 ```rust
-some_pred(?x, ?y) :- other_pred(?z), SumOf(?x, ?y, ?z), Lt(0, ?x)
+some_pred(x, y) :- other_pred(z), SumOf(x, y, z), Lt(0, x)
 ```
-**Handling**: Can't evaluate `SumOf(?x, ?y, ?z)` with multiple free variables → fall back to current behavior
+**Handling**: Can't evaluate `SumOf(x, y, z)` with multiple free variables → fall back to current behavior
 
 #### 2. Equal with Free Variables  
 ```rust
-some_pred(?x) :- other_pred(?y), Equal(?x, ?y), Lt(0, ?x)
+some_pred(x) :- other_pred(y), Equal(x, y), Lt(0, x)
 ```
-**Handling**: If `?y` is bound → can evaluate; if `?y` is free → fall back
+**Handling**: If `y` is bound → can evaluate; if `y` is free → fall back
 
 #### 3. Complex Constraint Chains
 ```rust
-some_pred(?a, ?b) :- other_pred(?c), SumOf(?a, ?c, 1), SumOf(?b, ?a, 2), Lt(0, ?b)
+some_pred(a, b) :- other_pred(c), SumOf(a, c, 1), SumOf(b, a, 2), Lt(0, b)
 ```
-**Handling**: If `?c` is bound → can evaluate entire chain; otherwise fall back
+**Handling**: If `c` is bound → can evaluate entire chain; otherwise fall back
 
 ### Limitations and Trade-offs
 
@@ -123,7 +123,7 @@ some_pred(?a, ?b) :- other_pred(?c), SumOf(?a, ?c, 1), SumOf(?b, ?a, 2), Lt(0, ?
 
 ### Testing Strategy
 
-Primary test case: `upvote_count` recursive predicate with `Lt(0, ?count)` constraint
+Primary test case: `upvote_count` recursive predicate with `Lt(0, count)` constraint
 - **Before fix**: Infinite loop with negative count values
 - **After fix**: Recursion terminates when count reaches 0
 

--- a/core/solver/src/engine/semi_naive.rs
+++ b/core/solver/src/engine/semi_naive.rs
@@ -967,10 +967,10 @@ mod tests {
         // 3. Define podlog and create plan
         let podlog = r#"
             is_large(P) = AND(
-                Lt(10, ?P["foo"])
+                Lt(10, P["foo"])
             )
             REQUEST(
-                is_large(?SomePod)
+                is_large(SomePod)
             )
         "#;
         let params = Params::default();
@@ -1052,12 +1052,12 @@ mod tests {
         let podlog = format!(
             r#"
             are_friends(A, B) = AND(
-                Equal(?A["id"], ?B["friend_id"])
-                NotEqual(?A, Raw(0x{self_hex}))
-                NotEqual(?B, Raw(0x{self_hex}))
+                Equal(A["id"], B["friend_id"])
+                NotEqual(A, Raw(0x{self_hex}))
+                NotEqual(B, Raw(0x{self_hex}))
             )
             REQUEST(
-                are_friends(?P1, ?P2)
+                are_friends(P1, P2)
             )
         "#
         );
@@ -1155,21 +1155,21 @@ mod tests {
         let podlog = format!(
             r#"
             edge(A, B) = AND(
-                Equal(?A["next"], ?B["id"])
+                Equal(A["next"], B["id"])
             )
 
             path(X, Y) = OR(
-                edge(?X, ?Y)
-                path_rec(?X, ?Y)
+                edge(X, Y)
+                path_rec(X, Y)
             )
 
             path_rec(X, Y, private: Z) = AND(
-                path(?X, ?Z)
-                edge(?Z, ?Y)
+                path(X, Z)
+                edge(Z, Y)
             )
 
             REQUEST(
-                path(0x{pod_a_id_hex}, ?End)
+                path(0x{pod_a_id_hex}, End)
             )
         "#
         );
@@ -1280,7 +1280,7 @@ mod tests {
 
         let program = r#"
         REQUEST(
-            Equal(?A["k1"], ?P["k4"])
+            Equal(A["k1"], P["k4"])
         )
         "#;
 
@@ -1338,7 +1338,7 @@ mod tests {
         // 3. Define podlog and create plan for a NATIVE predicate request
         let podlog = r#"
             REQUEST(
-                Lt(10, ?P["foo"])
+                Lt(10, P["foo"])
             )
         "#;
         let params = Params::default();
@@ -1390,7 +1390,7 @@ mod tests {
             r#"
         use _, _, _, eth_dos from 0x{}
         REQUEST(
-            eth_dos(0x{}, 0x{}, ?Distance)
+            eth_dos(0x{}, 0x{}, Distance)
         )
         "#,
             batch.id().encode_hex::<String>(),
@@ -1550,21 +1550,21 @@ mod tests {
         let podlog = format!(
             r#"
         edge(A, B) = AND(
-            Equal(?A["next"], ?B["id"])
+            Equal(A["next"], B["id"])
         )
 
         path_rec(X, Y, private: Z) =  AND(
-            path(?X, ?Z)
-            edge(?Z, ?Y)
+            path(X, Z)
+            edge(Z, Y)
         )
 
         path(X, Y) = OR(
-            edge(?X, ?Y)
-            path_rec(?X, ?Y)
+            edge(X, Y)
+            path_rec(X, Y)
         )
 
         REQUEST(
-            path(0x{pod_a_id_hex}, ?End)
+            path(0x{pod_a_id_hex}, End)
         )
     "#
         );
@@ -1648,29 +1648,29 @@ mod tests {
 
     //         let program = r#"
     //  sum_from_base(A, I, S) = AND(
-    //     NotContains(?A, ?I)        // I is past the end
-    //     SumOf(?S, 0, 0)            // therefore S = 0
+    //     NotContains(A, I)        // I is past the end
+    //     SumOf(S, 0, 0)            // therefore S = 0
     // )
 
     // sum_from_step(A, I, S, private: J, Rest, V) = AND(
-    //     Contains(?A, ?I, ?V)       // element V exists at index I
-    //     SumOf(?J, ?I, 1)           // J = I + 1
-    //     sum_from(?A, ?J, ?Rest)    // recursive call
-    //     SumOf(?S, ?V, ?Rest)       // S = V + Rest
+    //     Contains(A, I, V)       // element V exists at index I
+    //     SumOf(J, I, 1)           // J = I + 1
+    //     sum_from(A, J, Rest)    // recursive call
+    //     SumOf(S, V, Rest)       // S = V + Rest
     // )
 
     // // ------------ single public definition --------------------------
     // sum_from(A, I, S) = OR(
-    //     sum_from_base(?A, ?I, ?S)
-    //     sum_from_step(?A, ?I, ?S)
+    //     sum_from_base(A, I, S)
+    //     sum_from_step(A, I, S)
     // )
 
     // array_sum(A, S) = AND(
-    //     sum_from(?A, 0, ?S)
+    //     sum_from(A, 0, S)
     // )
     // // --- What a client would request ---------------------------------
     // REQUEST(
-    //     array_sum([1, 2, 3], ?Total)
+    //     array_sum([1, 2, 3], Total)
     // )
     //         "#;
 

--- a/core/solver/src/lib.rs
+++ b/core/solver/src/lib.rs
@@ -168,7 +168,7 @@ mod tests {
       use _, _, _, eth_dos from 0x{}
 
       REQUEST(
-          eth_dos({}, {}, ?Distance)
+          eth_dos({}, {}, Distance)
       )
       "#,
             batch.id().encode_hex::<String>(),
@@ -215,7 +215,7 @@ mod tests {
       use _, _, _, eth_dos from 0x{}
 
       REQUEST(
-          eth_dos({}, {}, ?Distance)
+          eth_dos({}, {}, Distance)
       )
       "#,
             batch.id().encode_hex::<String>(),
@@ -286,11 +286,11 @@ mod tests {
         let zukyc_request = format!(
             r#"
         REQUEST(
-            NotContains({sanction_set}, ?gov["idNumber"])
-            Lt(?gov["dateOfBirth"], {const_18y})
-            Equal(?pay["startDate"], {const_1y})
-            Equal(?gov["socialSecurityNumber"], ?pay["socialSecurityNumber"])
-            Equal(?self["watermark"], 0)
+            NotContains({sanction_set}, gov["idNumber"])
+            Lt(gov["dateOfBirth"], {const_18y})
+            Equal(pay["startDate"], {const_1y})
+            Equal(gov["socialSecurityNumber"], pay["socialSecurityNumber"])
+            Equal(self["watermark"], 0)
         )
         "#
         );
@@ -344,7 +344,7 @@ mod tests {
         let sk = SecretKey::new_rand();
         let pk = sk.public_key();
         let request = parse(
-            &format!("REQUEST(PublicKeyOf({}, ?b))", Value::from(pk)),
+            &format!("REQUEST(PublicKeyOf({}, b))", Value::from(pk)),
             &params,
             &[],
         )
@@ -385,12 +385,12 @@ mod tests {
             &format!(
                 r#"
 owned_public_key(pk, pod_id, private: sk) = AND(
-    PublicKeyOf(?pk, ?sk)
-    Equal(?pod_id, SELF)
+    PublicKeyOf(pk, sk)
+    Equal(pod_id, SELF)
 )
 
 REQUEST(
-    PublicKeyOf({pk}, ?sk)
+    PublicKeyOf({pk}, sk)
     owned_public_key({pk}, SELF)
 )
             "#

--- a/core/solver/src/pretty_print.rs
+++ b/core/solver/src/pretty_print.rs
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn test_format_wildcard() {
         let wildcard = Wildcard::new("count".to_string(), 0);
-        assert_eq!(format_wildcard(&wildcard), "?count");
+        assert_eq!(format_wildcard(&wildcard), "count");
     }
 
     #[test]
@@ -408,8 +408,8 @@ mod tests {
 
         let formatted = format_bindings(&bindings);
         // Should be sorted by key for consistent output
-        assert!(formatted.contains("?count: 42"));
-        assert!(formatted.contains("?name: \"alice\""));
+        assert!(formatted.contains("count: 42"));
+        assert!(formatted.contains("name: \"alice\""));
     }
 
     #[test]
@@ -427,7 +427,7 @@ mod tests {
     fn test_pretty_wildcard_wrapper() {
         let wildcard = Wildcard::new("test_var".to_string(), 0);
         let pretty_wildcard = PrettyWildcard(&wildcard);
-        assert_eq!(pretty_wildcard.to_string(), "?test_var");
+        assert_eq!(pretty_wildcard.to_string(), "test_var");
     }
 
     #[test]

--- a/core/solver/src/semantics/materializer.rs
+++ b/core/solver/src/semantics/materializer.rs
@@ -68,13 +68,13 @@ impl MaterializeKey {
 /// to find any valid statements compatible with those bindings, with the caveat that
 /// the bindings must typically provide enough information to find relevant statements.
 ///
-/// For example, Equal(?a, ?b) where ?a and ?b are free variables is compatible with
+/// For example, Equal(a, b) where a and b are free variables is compatible with
 /// *any* Equal statement. As such, we will not materialize any statements in response
 /// to this query.
 ///
-/// However, Equal(?a["foo"], ?b["bar"]), where ?a and ?b are free variables, is
+/// However, Equal(a["foo"], b["bar"]), where a and b are free variables, is
 /// constrained by the key part, and so in this case we would materialize and Equal
-/// statement where ?a["foo"] = ?b["bar"].
+/// statement where a["foo"] = b["bar"].
 ///
 /// Predicate-specific handlers are responsible for determining whether a statement
 /// is valid, and for deducing the values of free variables.

--- a/core/solver/src/semantics/operation_materializers.rs
+++ b/core/solver/src/semantics/operation_materializers.rs
@@ -280,7 +280,7 @@ fn materialize_equal_from_entries_with_deduction(
     }
 
     let deduced_args = match (&args[0], &args[1]) {
-        // ?X == bound -> bind ?X
+        // X == bound -> bind X
         (None, Some(vr1)) => {
             if let ValueRef::Key(_) = vr1 {
                 // If the bound argument is an anchored key, we can set the
@@ -291,7 +291,7 @@ fn materialize_equal_from_entries_with_deduction(
                 Some(vec![vr1.clone(), vr1.clone()])
             }
         }
-        // bound == ?Y -> bind ?Y
+        // bound == Y -> bind Y
         (Some(vr0), None) => {
             if let ValueRef::Key(_) = vr0 {
                 db.value_ref_to_value(vr0)
@@ -633,7 +633,7 @@ fn materialize_sum_of(args: &[Option<ValueRef>], db: &FactDB) -> Option<Fact> {
 
     // Try deduction with free args first
     let deduced_args = match (&args[0], &args[1], &args[2]) {
-        // SumOf(?x, 5, 10) -> x = 15
+        // SumOf(x, 5, 10) -> x = 15
         (None, Some(vr1), Some(vr2)) => {
             if let (Some(i1), Some(i2)) = (int(vr1), int(vr2)) {
                 Some(vec![ValueRef::from(i1 + i2), vr1.clone(), vr2.clone()])
@@ -641,7 +641,7 @@ fn materialize_sum_of(args: &[Option<ValueRef>], db: &FactDB) -> Option<Fact> {
                 None
             }
         }
-        // SumOf(15, ?y, 10) -> y = 5
+        // SumOf(15, y, 10) -> y = 5
         (Some(vr0), None, Some(vr2)) => {
             if let (Some(i0), Some(i2)) = (int(vr0), int(vr2)) {
                 Some(vec![vr0.clone(), ValueRef::from(i0 - i2), vr2.clone()])
@@ -649,7 +649,7 @@ fn materialize_sum_of(args: &[Option<ValueRef>], db: &FactDB) -> Option<Fact> {
                 None
             }
         }
-        // SumOf(15, 5, ?z) -> z = 10
+        // SumOf(15, 5, z) -> z = 10
         (Some(vr0), Some(vr1), None) => {
             if let (Some(i0), Some(i1)) = (int(vr0), int(vr1)) {
                 Some(vec![vr0.clone(), vr1.clone(), ValueRef::from(i0 - i1)])
@@ -694,7 +694,7 @@ fn materialize_product_of(args: &[Option<ValueRef>], db: &FactDB) -> Option<Fact
 
     // Try deduction with free args first
     let deduced_args = match (&args[0], &args[1], &args[2]) {
-        // ProductOf(?x, 5, 10) -> x = 50
+        // ProductOf(x, 5, 10) -> x = 50
         (None, Some(vr1), Some(vr2)) => {
             if let (Some(i1), Some(i2)) = (int(vr1), int(vr2)) {
                 Some(vec![ValueRef::from(i1 * i2), vr1.clone(), vr2.clone()])
@@ -702,7 +702,7 @@ fn materialize_product_of(args: &[Option<ValueRef>], db: &FactDB) -> Option<Fact
                 None
             }
         }
-        // ProductOf(50, ?y, 10) -> y = 5
+        // ProductOf(50, y, 10) -> y = 5
         (Some(vr0), None, Some(vr2)) => {
             if let (Some(i0), Some(i2)) = (int(vr0), int(vr2)) {
                 if i2 != 0 {
@@ -714,7 +714,7 @@ fn materialize_product_of(args: &[Option<ValueRef>], db: &FactDB) -> Option<Fact
                 None
             }
         }
-        // ProductOf(50, 5, ?z) -> z = 10
+        // ProductOf(50, 5, z) -> z = 10
         (Some(vr0), Some(vr1), None) => {
             if let (Some(i0), Some(i1)) = (int(vr0), int(vr1)) {
                 if i1 != 0 {
@@ -763,7 +763,7 @@ fn materialize_max_of(args: &[Option<ValueRef>], db: &FactDB) -> Option<Fact> {
 
     // Try deduction with free args first
     let deduced_args = match (&args[0], &args[1], &args[2]) {
-        // MaxOf(?x, 5, 10) -> x = 10
+        // MaxOf(x, 5, 10) -> x = 10
         (None, Some(vr1), Some(vr2)) => {
             if let (Some(i1), Some(i2)) = (int(vr1), int(vr2)) {
                 Some(vec![ValueRef::from(i1.max(i2)), vr1.clone(), vr2.clone()])
@@ -771,7 +771,7 @@ fn materialize_max_of(args: &[Option<ValueRef>], db: &FactDB) -> Option<Fact> {
                 None
             }
         }
-        // MaxOf(10, ?y, 10) -> y could be anything <= 10, but we'll use the max value for consistency
+        // MaxOf(10, y, 10) -> y could be anything <= 10, but we'll use the max value for consistency
         (Some(vr0), None, Some(vr2)) => {
             if let (Some(i0), Some(i2)) = (int(vr0), int(vr2)) {
                 Some(vec![vr0.clone(), ValueRef::from(i0.max(i2)), vr2.clone()])
@@ -779,7 +779,7 @@ fn materialize_max_of(args: &[Option<ValueRef>], db: &FactDB) -> Option<Fact> {
                 None
             }
         }
-        // MaxOf(10, 10, ?z) -> z could be anything <= 10
+        // MaxOf(10, 10, z) -> z could be anything <= 10
         (Some(vr0), Some(vr1), None) => {
             if let (Some(i0), Some(i1)) = (int(vr0), int(vr1)) {
                 Some(vec![vr0.clone(), vr1.clone(), ValueRef::from(i0.max(i1))])
@@ -817,7 +817,7 @@ fn materialize_hash_of(args: &[Option<ValueRef>], db: &FactDB) -> Option<Fact> {
 
     // Try deduction with free args first
     let deduced_args = match (&args[0], &args[1], &args[2]) {
-        // HashOf(?x, 5, 10) -> x = hash(5, 10)
+        // HashOf(x, 5, 10) -> x = hash(5, 10)
         (None, Some(vr1), Some(vr2)) => {
             if let (Some(val1), Some(val2)) =
                 (db.value_ref_to_value(vr1), db.value_ref_to_value(vr2))
@@ -831,12 +831,12 @@ fn materialize_hash_of(args: &[Option<ValueRef>], db: &FactDB) -> Option<Fact> {
                 None
             }
         }
-        // HashOf(hash_val, ?y, 10) -> y = ? (cannot easily reverse hash)
+        // HashOf(hash_val, y, 10) -> y = ? (cannot easily reverse hash)
         (Some(_vr0), None, Some(_vr2)) => {
             // Cannot easily reverse hash functions, so we don't support this deduction
             None
         }
-        // HashOf(hash_val, 5, ?z) -> z = ? (cannot easily reverse hash)
+        // HashOf(hash_val, 5, z) -> z = ? (cannot easily reverse hash)
         (Some(_vr0), Some(_vr1), None) => {
             // Cannot easily reverse hash functions, so we don't support this deduction
             None

--- a/core/solver/src/semantics/operation_materializers_test.rs
+++ b/core/solver/src/semantics/operation_materializers_test.rs
@@ -330,7 +330,7 @@ mod tests {
         let db = create_test_db();
         let materializer = OperationMaterializer::SumOf;
 
-        // SumOf(?x, 5, 10) -> x = 15
+        // SumOf(x, 5, 10) -> x = 15
         let args = vec![None, Some(val_ref_int(5)), Some(val_ref_int(10))];
         let result = materializer.materialize(&args, &db, NativePredicate::SumOf);
 
@@ -346,7 +346,7 @@ mod tests {
         let db = create_test_db();
         let materializer = OperationMaterializer::SumOf;
 
-        // SumOf(15, ?y, 10) -> y = 5
+        // SumOf(15, y, 10) -> y = 5
         let args = vec![Some(val_ref_int(15)), None, Some(val_ref_int(10))];
         let result = materializer.materialize(&args, &db, NativePredicate::SumOf);
 
@@ -362,7 +362,7 @@ mod tests {
         let db = create_test_db();
         let materializer = OperationMaterializer::SumOf;
 
-        // SumOf(15, 5, ?z) -> z = 10
+        // SumOf(15, 5, z) -> z = 10
         let args = vec![Some(val_ref_int(15)), Some(val_ref_int(5)), None];
         let result = materializer.materialize(&args, &db, NativePredicate::SumOf);
 
@@ -410,7 +410,7 @@ mod tests {
         let db = create_test_db();
         let materializer = OperationMaterializer::ProductOf;
 
-        // ProductOf(?x, 5, 10) -> x = 50
+        // ProductOf(x, 5, 10) -> x = 50
         let args = vec![None, Some(val_ref_int(5)), Some(val_ref_int(10))];
         let result = materializer.materialize(&args, &db, NativePredicate::ProductOf);
 
@@ -426,7 +426,7 @@ mod tests {
         let db = create_test_db();
         let materializer = OperationMaterializer::ProductOf;
 
-        // ProductOf(50, ?y, 10) -> y = 5
+        // ProductOf(50, y, 10) -> y = 5
         let args = vec![Some(val_ref_int(50)), None, Some(val_ref_int(10))];
         let result = materializer.materialize(&args, &db, NativePredicate::ProductOf);
 
@@ -442,7 +442,7 @@ mod tests {
         let db = create_test_db();
         let materializer = OperationMaterializer::ProductOf;
 
-        // ProductOf(50, ?y, 0) -> division by zero, should fail
+        // ProductOf(50, y, 0) -> division by zero, should fail
         let args = vec![Some(val_ref_int(50)), None, Some(val_ref_int(0))];
         let result = materializer.materialize(&args, &db, NativePredicate::ProductOf);
 
@@ -475,7 +475,7 @@ mod tests {
         let db = create_test_db();
         let materializer = OperationMaterializer::MaxOf;
 
-        // MaxOf(?x, 5, 10) -> x = 10
+        // MaxOf(x, 5, 10) -> x = 10
         let args = vec![None, Some(val_ref_int(5)), Some(val_ref_int(10))];
         let result = materializer.materialize(&args, &db, NativePredicate::MaxOf);
 
@@ -509,7 +509,7 @@ mod tests {
         let db = create_test_db();
         let materializer = OperationMaterializer::HashOf;
 
-        // HashOf(?x, 5, 10) -> x = hash(5, 10)
+        // HashOf(x, 5, 10) -> x = hash(5, 10)
         let args = vec![None, Some(val_ref_int(5)), Some(val_ref_int(10))];
         let result = materializer.materialize(&args, &db, NativePredicate::HashOf);
 
@@ -569,7 +569,7 @@ mod tests {
         let db = create_test_db();
         let materializer = OperationMaterializer::HashOf;
 
-        // HashOf(hash_val, ?y, 10) -> cannot deduce y from hash (not supported)
+        // HashOf(hash_val, y, 10) -> cannot deduce y from hash (not supported)
         let args = vec![Some(val_ref_str("some_hash")), None, Some(val_ref_int(10))];
         let result = materializer.materialize(&args, &db, NativePredicate::HashOf);
 

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -79,16 +79,16 @@ Note: The ultimate source of truth on the objects each route requests is in
 
 ```
 identity_verified(username, private: identity_pod) = AND(
-    Equal(?identity_pod["_type"], SIGNED_POD)
-    Equal(?identity_pod["username"], ?username)
+    Equal(identity_pod["_type"], SIGNED_POD)
+    Equal(identity_pod["username"], username)
 )
 
 publish_verified(username, data, identity_server_pk, private: identity_pod, document_pod) = AND(
-    identity_verified(?username)
-    Equal(?document_pod["request_type"], "publish")
-    Equal(?document_pod["data"], ?data)
-    Equal(?document_pod["_signer"], ?identity_pod["user_public_key"])
-    Equal(?identity_pod["_signer"], ?identity_server_pk)
+    identity_verified(username)
+    Equal(document_pod["request_type"], "publish")
+    Equal(document_pod["data"], data)
+    Equal(document_pod["_signer"], identity_pod["user_public_key"])
+    Equal(identity_pod["_signer"], identity_server_pk)
 )
 ```
 
@@ -286,21 +286,21 @@ This ensures the main server controls challenge generation and the identity serv
 
 ```
 identity_verified(username, private: identity_pod) = AND(
-    Equal(?identity_pod["_type"], SIGNED_POD)
-    Equal(?identity_pod["username"], ?username)
+    Equal(identity_pod["_type"], SIGNED_POD)
+    Equal(identity_pod["username"], username)
 )
 
 upvote_verified(content_hash, private: upvote_pod) = AND(
-    Equal(?upvote_pod["_type"], SIGNED_POD)
-    Equal(?upvote_pod["content_hash"], ?content_hash)
-    Equal(?upvote_pod["request_type"], "upvote")
+    Equal(upvote_pod["_type"], SIGNED_POD)
+    Equal(upvote_pod["content_hash"], content_hash)
+    Equal(upvote_pod["request_type"], "upvote")
 )
 
 upvote_verification(username, content_hash, identity_server_pk, private: identity_pod, upvote_pod) = AND(
-    identity_verified(?username)
-    upvote_verified(?content_hash)
-    Equal(?identity_pod["_signer"], ?identity_server_pk)
-    Equal(?identity_pod["user_public_key"], ?upvote_pod["_signer"])
+    identity_verified(username)
+    upvote_verified(content_hash)
+    Equal(identity_pod["_signer"], identity_server_pk)
+    Equal(identity_pod["user_public_key"], upvote_pod["_signer"])
 )
 ```
 
@@ -357,19 +357,19 @@ upvote_verification(username, content_hash, identity_server_pk, private: identit
 use _, _, upvote_verification from [upvote_batch_id]
 
 upvote_count_base(count, content_hash, private: data_pod) = AND(
-    Equal(?count, 0)
-    Equal(?data_pod["content_hash"], ?content_hash)
+    Equal(count, 0)
+    Equal(data_pod["content_hash"], content_hash)
 )
 
 upvote_count_ind(count, content_hash, private: intermed, username, identity_server_pk) = AND(
-    upvote_count(?intermed, ?content_hash)
-    SumOf(?count, ?intermed, 1)
-    upvote_verification(?username, ?content_hash, ?identity_server_pk)
+    upvote_count(intermed, content_hash)
+    SumOf(count, intermed, 1)
+    upvote_verification(username, content_hash, identity_server_pk)
 )
 
 upvote_count(count, content_hash) = OR(
-    upvote_count_base(?count, ?content_hash)
-    upvote_count_ind(?count, ?content_hash)
+    upvote_count_base(count, content_hash)
+    upvote_count_ind(count, content_hash)
 )
 ```
 

--- a/pod2-client/db/src/store.rs
+++ b/pod2-client/db/src/store.rs
@@ -691,7 +691,7 @@ pub async fn get_default_private_key(db: &Db) -> Result<SecretKey> {
                 Err(rusqlite::Error::QueryReturnedNoRows) => Err(anyhow::anyhow!(
                     "No default private key found after ensuring one exists"
                 )),
-                Err(e) => Err(anyhow::anyhow!("Database error: {}", e)),
+                Err(e) => Err(anyhow::anyhow!("Database error: {e}")),
             }
         })
         .await
@@ -738,7 +738,7 @@ pub async fn get_default_private_key_info(db: &Db) -> Result<serde_json::Value> 
                 Err(rusqlite::Error::QueryReturnedNoRows) => {
                     Err(anyhow::anyhow!("No default private key found after ensuring one exists"))
                 }
-                Err(e) => Err(anyhow::anyhow!("Database error: {}", e)),
+                Err(e) => Err(anyhow::anyhow!("Database error: {e}")),
             }
         })
         .await
@@ -1030,7 +1030,7 @@ pub async fn is_setup_completed(db: &Db) -> Result<bool> {
             match result {
                 Ok(completed) => Ok(completed),
                 Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false), // No setup record means not completed
-                Err(e) => Err(anyhow::anyhow!("Database error: {}", e)),
+                Err(e) => Err(anyhow::anyhow!("Database error: {e}")),
             }
         })
         .await
@@ -1081,7 +1081,7 @@ pub async fn get_app_setup_state(db: &Db) -> Result<AppSetupState> {
                         created_at: Utc::now().to_rfc3339(),
                     })
                 }
-                Err(e) => Err(anyhow::anyhow!("Database error: {}", e)),
+                Err(e) => Err(anyhow::anyhow!("Database error: {e}")),
             }
         })
         .await
@@ -1224,7 +1224,7 @@ pub async fn get_default_private_key_raw(db: &Db) -> Result<SecretKey> {
                 Err(rusqlite::Error::QueryReturnedNoRows) => {
                     Err(anyhow::anyhow!("No default private key found"))
                 }
-                Err(e) => Err(anyhow::anyhow!("Database error: {}", e)),
+                Err(e) => Err(anyhow::anyhow!("Database error: {e}")),
             }
         })
         .await

--- a/pod2-client/db/src/store.rs
+++ b/pod2-client/db/src/store.rs
@@ -109,7 +109,7 @@ pub async fn create_space(db: &Db, id: &str) -> Result<()> {
         )
     })
     .await
-    .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+    .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
     .context("DB interaction failed for create_space")??;
 
     Ok(())
@@ -134,7 +134,7 @@ pub async fn list_spaces(db: &Db) -> Result<Vec<SpaceInfo>> {
             space_iter.collect::<Result<Vec<_>, _>>()
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for list_spaces")??;
 
     Ok(spaces)
@@ -153,7 +153,7 @@ pub async fn space_exists(db: &Db, id: &str) -> Result<bool> {
             stmt.exists([id_clone])
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for space existence check")??;
     Ok(exists)
 }
@@ -169,7 +169,7 @@ pub async fn delete_space(db: &Db, id: &str) -> Result<usize> {
     let rows_deleted = conn
         .interact(move |conn| conn.execute("DELETE FROM spaces WHERE id = ?1", [&id_clone]))
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for delete_space")??;
 
     Ok(rows_deleted)
@@ -212,7 +212,7 @@ pub async fn import_pod(
         )
     })
     .await
-    .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+    .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
     .context("DB interaction failed for import_pod")??;
 
     Ok(())
@@ -259,7 +259,7 @@ pub async fn get_pod(db: &Db, space_id: &str, pod_id: &str) -> Result<Option<Pod
             }
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for get_pod")??;
 
     Ok(pod_info_result)
@@ -340,7 +340,7 @@ async fn list_pods_filtered(
             }
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for list_pods_filtered")??;
     Ok(pods)
 }
@@ -386,7 +386,7 @@ pub async fn delete_pod(db: &Db, space_id: &str, pod_id: &str) -> Result<usize> 
             }
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for delete_pod")??;
     Ok(rows_deleted)
 }
@@ -403,7 +403,7 @@ pub async fn count_all_pods(db: &Db) -> Result<u32> {
         Ok(count as u32)
     })
     .await
-    .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+    .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
     .context("DB interaction failed for count_all_pods")?
 }
 
@@ -429,7 +429,7 @@ pub async fn count_pods_by_type(db: &Db) -> Result<(u32, u32)> {
             Ok::<_, rusqlite::Error>((signed_count as u32, main_count as u32))
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for count_pods_by_type")??;
 
     Ok(counts)
@@ -477,7 +477,7 @@ pub async fn add_inbox_message(
         )
     })
     .await
-    .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+    .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
     .context("DB interaction failed for add_inbox_message")??;
 
     Ok(message_id)
@@ -514,7 +514,7 @@ pub async fn get_inbox_messages(db: &Db) -> Result<Vec<serde_json::Value>> {
             message_iter.collect::<Result<Vec<_>, _>>()
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for get_inbox_messages")??;
 
     Ok(messages)
@@ -598,7 +598,7 @@ pub async fn accept_inbox_message(
             Ok(chat_id)
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for accept_inbox_message")??;
 
     Ok(chat_id)
@@ -655,7 +655,7 @@ pub async fn regenerate_public_keys_if_needed(db: &Db) -> Result<()> {
             Ok::<i32, rusqlite::Error>(count)
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for regenerate_public_keys_if_needed")??;
 
     if updated_count > 0 {
@@ -695,7 +695,7 @@ pub async fn get_default_private_key(db: &Db) -> Result<SecretKey> {
             }
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for get_default_private_key")??;
 
     let bytes = hex::decode(key_hex).context("Failed to decode private key hex")?;
@@ -742,7 +742,7 @@ pub async fn get_default_private_key_info(db: &Db) -> Result<serde_json::Value> 
             }
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for get_default_private_key_info")??;
 
     Ok(key_info)
@@ -779,7 +779,7 @@ pub async fn get_chats(db: &Db) -> Result<Vec<serde_json::Value>> {
             chat_iter.collect::<Result<Vec<_>, _>>()
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for get_chats")??;
 
     Ok(chats)
@@ -817,7 +817,7 @@ pub async fn get_chat_messages(db: &Db, chat_id: &str) -> Result<Vec<serde_json:
             message_iter.collect::<Result<Vec<_>, _>>()
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for get_chat_messages")??;
 
     Ok(messages)
@@ -888,7 +888,7 @@ pub async fn add_sent_message_to_chat(
             Ok(message_id)
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for add_sent_message_to_chat")??;
 
     Ok(message_id)
@@ -953,7 +953,7 @@ pub async fn import_pod_and_add_to_inbox(
         Ok(message_id_clone)
     })
     .await
-    .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+    .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
     .context("DB interaction failed for import_pod_and_add_to_inbox")??;
 
     Ok(message_id)
@@ -993,7 +993,7 @@ pub async fn list_all_pods(db: &Db) -> Result<Vec<PodInfo>> {
             pod_iter.collect::<Result<Vec<_>, _>>()
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for list_all_pods")??;
 
     Ok(pods)
@@ -1034,7 +1034,7 @@ pub async fn is_setup_completed(db: &Db) -> Result<bool> {
             }
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for is_setup_completed")??;
 
     Ok(setup_completed)
@@ -1085,7 +1085,7 @@ pub async fn get_app_setup_state(db: &Db) -> Result<AppSetupState> {
             }
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for get_app_setup_state")??;
 
     Ok(setup_state)
@@ -1115,7 +1115,7 @@ pub async fn update_identity_server_info(
         )
     })
     .await
-    .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+    .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
     .context("DB interaction failed for update_identity_server_info")??;
 
     Ok(())
@@ -1139,7 +1139,7 @@ pub async fn update_identity_info(db: &Db, username: &str, identity_pod_id: &str
         )
     })
     .await
-    .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+    .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
     .context("DB interaction failed for update_identity_info")??;
 
     Ok(())
@@ -1161,7 +1161,7 @@ pub async fn complete_app_setup(db: &Db) -> Result<()> {
         )
     })
     .await
-    .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+    .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
     .context("DB interaction failed for complete_app_setup")??;
 
     Ok(())
@@ -1199,7 +1199,7 @@ pub async fn store_identity_pod(
         )
     })
     .await
-    .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+    .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
     .context("DB interaction failed for store_identity_pod")??;
 
     Ok(())
@@ -1228,7 +1228,7 @@ pub async fn get_default_private_key_raw(db: &Db) -> Result<SecretKey> {
             }
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for get_default_private_key_raw")??;
 
     let bytes = hex::decode(key_hex).context("Failed to decode private key hex")?;
@@ -1270,7 +1270,7 @@ pub async fn create_default_private_key(db: &Db) -> Result<SecretKey> {
         )
     })
     .await
-    .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+    .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
     .context("DB interaction failed for create_default_private_key")??;
 
     log::info!("Created default private key during setup");
@@ -1364,7 +1364,7 @@ pub async fn create_draft(db: &Db, request: CreateDraftRequest) -> Result<String
         Ok(())
     })
     .await
-    .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+    .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
     .context("DB interaction failed for create_draft")??;
 
     log::info!("Created new draft with UUID: {draft_id}");
@@ -1425,7 +1425,7 @@ pub async fn list_drafts(db: &Db) -> Result<Vec<DraftInfo>> {
             draft_iter.collect::<Result<Vec<_>, _>>()
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for list_drafts")??;
 
     Ok(drafts)
@@ -1489,7 +1489,7 @@ pub async fn get_draft(db: &Db, draft_id: &str) -> Result<Option<DraftInfo>> {
             }
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for get_draft")??;
 
     Ok(draft)
@@ -1532,7 +1532,7 @@ pub async fn update_draft(db: &Db, draft_id: &str, request: UpdateDraftRequest) 
             )
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for update_draft")??;
 
     Ok(rows_affected > 0)
@@ -1555,7 +1555,7 @@ pub async fn delete_draft(db: &Db, draft_id: &str) -> Result<bool> {
             )
         })
         .await
-        .map_err(|e| anyhow::anyhow!("InteractError: {}", e))
+        .map_err(|e| anyhow::anyhow!("InteractError: {e}"))
         .context("DB interaction failed for delete_draft")??;
 
     Ok(rows_affected > 0)


### PR DESCRIPTION
PODLang breaking change removes ? from wildcards.  This PR updates the pod2 repo pointer to the latest, and updates wildcards in this repo to the new format.

I did the replacement with a regex in VSCode.  Unlike in the pod2 repo, I had to tweak it to avoid several classes of false-positives of things which look like PODLang wildcards but aren't.  Documenting the regex I used for posterity, so that others can apply it on their own branches:

regex: `(?<!\w|trace(?:.|\n){0,100}|debug(?:.|\n){0,100}|https?://(?:.|\n){0,100})\?([A-Za-z]\w*)(?!\w|=)`
replace with: `$1`
exclude files: `*.cjs`

As far as I can tell from local Rust tests and the GitHub workflow tests above, this seems to be correct.
I don't know how to build and run the PODNet Client myself, though, so I haven't tested beyond what's automated.
I'm not expecting a line-by-line review here since it's all automated.  I'm hoping @robknight can quickly stanity-check any false-positives I may have missed, and confirm the client isn't entirely broken.